### PR TITLE
Update MouseEvent.pos() to .position()

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file DisplayScenesInTabletopAR.cpp
+// [WriteFile Name=DisplayScenesInTabletopAR, Category=AR]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -190,7 +178,7 @@ void DisplayScenesInTabletopAR::onMouseClicked(QMouseEvent& event)
   m_sceneView->arcGISScene()->baseSurface()->setNavigationConstraint(NavigationConstraint::None);
 
   // Set the initial transformation using the point clicked on the screen
-  const QPoint screenPoint = event.localposition().toPoint();
+  const QPoint screenPoint = event.localPos().toPoint();
   m_arcGISArView->setInitialTransformation(screenPoint);
 
   // Set the origin camera.
@@ -202,3 +190,4 @@ void DisplayScenesInTabletopAR::onMouseClicked(QMouseEvent& event)
   emit sceneViewChanged();
   emit arcGISArViewChanged();
 }
+

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=DisplayScenesInTabletopAR, Category=AR]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file DisplayScenesInTabletopAR.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -178,7 +190,7 @@ void DisplayScenesInTabletopAR::onMouseClicked(QMouseEvent& event)
   m_sceneView->arcGISScene()->baseSurface()->setNavigationConstraint(NavigationConstraint::None);
 
   // Set the initial transformation using the point clicked on the screen
-  const QPoint screenPoint = event.localPos().toPoint();
+  const QPoint screenPoint = event.localposition().toPoint();
   m_arcGISArView->setInitialTransformation(screenPoint);
 
   // Set the origin camera.
@@ -190,4 +202,3 @@ void DisplayScenesInTabletopAR::onMouseClicked(QMouseEvent& event)
   emit sceneViewChanged();
   emit arcGISArViewChanged();
 }
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=AnalyzeViewshed, Category=Analysis]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file AnalyzeViewshed.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,7 +145,7 @@ void AnalyzeViewshed::connectSignals()
     }
 
     // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
-    Point mapPoint = m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouse.position().x(), mouse.position().y());
     if (m_inputGraphic)
       m_inputGraphic->setGeometry(mapPoint);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.cpp
@@ -133,7 +133,7 @@ void AnalyzeViewshed::connectSignals()
     }
 
     // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
-    Point mapPoint = m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouse.position().x(), mouse.position().y());
     if (m_inputGraphic)
       m_inputGraphic->setGeometry(mapPoint);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/AnalyzeViewshed.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file AnalyzeViewshed.cpp
+// [WriteFile Name=AnalyzeViewshed, Category=Analysis]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,7 +133,7 @@ void AnalyzeViewshed::connectSignals()
     }
 
     // Create a marker graphic where the user clicked on the map and add it to the existing graphics overlay
-    Point mapPoint = m_mapView->screenToLocation(mouse.position().x(), mouse.position().y());
+    Point mapPoint = m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y());
     if (m_inputGraphic)
       m_inputGraphic->setGeometry(mapPoint);
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
@@ -131,7 +131,7 @@ void DistanceMeasurementAnalysis::connectSignals()
   connect(m_sceneView, &SceneQuickView::mousePressedAndHeld, this, [this](QMouseEvent& mouseEvent)
   {
     m_isPressAndHold = true;
-    m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   });
 
   // When the mouse is released...
@@ -153,14 +153,14 @@ void DistanceMeasurementAnalysis::connectSignals()
       m_isPressAndHold = false;
     // Else get the location from the screen coordinates
     else
-      m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+      m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   });
 
   // Update the distance analysis when the mouse moves if it is a press and hold movement
   connect(m_sceneView, &SceneQuickView::mouseMoved, this, [this](QMouseEvent& mouseEvent)
   {
     if (m_isPressAndHold)
-      m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+      m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   });
 
   // Set a flag when mousePressed signal emits

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file DistanceMeasurementAnalysis.cpp
+// [WriteFile Name=DistanceMeasurementAnalysis, Category=Analysis]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,7 +131,7 @@ void DistanceMeasurementAnalysis::connectSignals()
   connect(m_sceneView, &SceneQuickView::mousePressedAndHeld, this, [this](QMouseEvent& mouseEvent)
   {
     m_isPressAndHold = true;
-    m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
   });
 
   // When the mouse is released...
@@ -165,14 +153,14 @@ void DistanceMeasurementAnalysis::connectSignals()
       m_isPressAndHold = false;
     // Else get the location from the screen coordinates
     else
-      m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+      m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
   });
 
   // Update the distance analysis when the mouse moves if it is a press and hold movement
   connect(m_sceneView, &SceneQuickView::mouseMoved, this, [this](QMouseEvent& mouseEvent)
   {
     if (m_isPressAndHold)
-      m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+      m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
   });
 
   // Set a flag when mousePressed signal emits

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/DistanceMeasurementAnalysis.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=DistanceMeasurementAnalysis, Category=Analysis]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file DistanceMeasurementAnalysis.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,7 +143,7 @@ void DistanceMeasurementAnalysis::connectSignals()
   connect(m_sceneView, &SceneQuickView::mousePressedAndHeld, this, [this](QMouseEvent& mouseEvent)
   {
     m_isPressAndHold = true;
-    m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   });
 
   // When the mouse is released...
@@ -153,14 +165,14 @@ void DistanceMeasurementAnalysis::connectSignals()
       m_isPressAndHold = false;
     // Else get the location from the screen coordinates
     else
-      m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+      m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   });
 
   // Update the distance analysis when the mouse moves if it is a press and hold movement
   connect(m_sceneView, &SceneQuickView::mouseMoved, this, [this](QMouseEvent& mouseEvent)
   {
     if (m_isPressAndHold)
-      m_sceneView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+      m_sceneView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   });
 
   // Set a flag when mousePressed signal emits

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
@@ -111,7 +111,7 @@ void LineOfSightLocation::connectSignals()
   // on mouse click perform the location viewshed
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
-    const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+    const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
     m_lineOfSight->setTargetLocation(pt);
   });
 
@@ -124,7 +124,7 @@ void LineOfSightLocation::connectSignals()
   {
     if (m_calculating)
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
       m_lineOfSight->setTargetLocation(pt);
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file LineOfSightLocation.cpp
+// [WriteFile Name=LineOfSightLocation, Category=Analysis]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,7 +111,7 @@ void LineOfSightLocation::connectSignals()
   // on mouse click perform the location viewshed
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
-    const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
+    const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
     m_lineOfSight->setTargetLocation(pt);
   });
 
@@ -136,7 +124,7 @@ void LineOfSightLocation::connectSignals()
   {
     if (m_calculating)
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
       m_lineOfSight->setTargetLocation(pt);
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/LineOfSightLocation.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=LineOfSightLocation, Category=Analysis]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file LineOfSightLocation.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,7 +123,7 @@ void LineOfSightLocation::connectSignals()
   // on mouse click perform the location viewshed
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
-    const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+    const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
     m_lineOfSight->setTargetLocation(pt);
   });
 
@@ -124,7 +136,7 @@ void LineOfSightLocation::connectSignals()
   {
     if (m_calculating)
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
       m_lineOfSight->setTargetLocation(pt);
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ViewshedGeoElement.cpp
+// [WriteFile Name=ViewshedGeoElement, Category=Analysis]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -163,7 +151,7 @@ void ViewshedGeoElement::componentComplete()
   // connect to the mouse clicked signal
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
-    m_waypoint = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
+    m_waypoint = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
     m_timer->start();
   });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
@@ -151,7 +151,7 @@ void ViewshedGeoElement::componentComplete()
   // connect to the mouse clicked signal
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
-    m_waypoint = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+    m_waypoint = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
     m_timer->start();
   });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/ViewshedGeoElement.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ViewshedGeoElement, Category=Analysis]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ViewshedGeoElement.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -151,7 +163,7 @@ void ViewshedGeoElement::componentComplete()
   // connect to the mouse clicked signal
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
-    m_waypoint = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+    m_waypoint = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
     m_timer->start();
   });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ViewshedLocation.cpp
+// [WriteFile Name=ViewshedLocation, Category=Analysis]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,10 +96,10 @@ void ViewshedLocation::connectSignals()
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
     if (!m_locationViewshed)
-      createViewshed(event.position().x(), event.position().y());
+      createViewshed(event.pos().x(), event.pos().y());
     else
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
       m_locationViewshed->setLocation(pt);
     }
   });
@@ -119,7 +107,7 @@ void ViewshedLocation::connectSignals()
   connect(m_sceneView, &SceneQuickView::mousePressedAndHeld, this, [this](QMouseEvent& event)
   {
     if (!m_locationViewshed)
-      createViewshed(event.position().x(), event.position().y());
+      createViewshed(event.pos().x(), event.pos().y());
 
     m_calculating = true;
   });
@@ -128,7 +116,7 @@ void ViewshedLocation::connectSignals()
   {
     if (m_calculating)
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
       m_locationViewshed->setLocation(pt);
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ViewshedLocation, Category=Analysis]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ViewshedLocation.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,10 +108,10 @@ void ViewshedLocation::connectSignals()
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
     if (!m_locationViewshed)
-      createViewshed(event.pos().x(), event.pos().y());
+      createViewshed(event.position().x(), event.position().y());
     else
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
       m_locationViewshed->setLocation(pt);
     }
   });
@@ -107,7 +119,7 @@ void ViewshedLocation::connectSignals()
   connect(m_sceneView, &SceneQuickView::mousePressedAndHeld, this, [this](QMouseEvent& event)
   {
     if (!m_locationViewshed)
-      createViewshed(event.pos().x(), event.pos().y());
+      createViewshed(event.position().x(), event.position().y());
 
     m_calculating = true;
   });
@@ -116,7 +128,7 @@ void ViewshedLocation::connectSignals()
   {
     if (m_calculating)
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
       m_locationViewshed->setLocation(pt);
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/ViewshedLocation.cpp
@@ -96,10 +96,10 @@ void ViewshedLocation::connectSignals()
   connect(m_sceneView, &SceneQuickView::mouseClicked, this, [this](QMouseEvent& event)
   {
     if (!m_locationViewshed)
-      createViewshed(event.pos().x(), event.pos().y());
+      createViewshed(event.position().x(), event.position().y());
     else
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
       m_locationViewshed->setLocation(pt);
     }
   });
@@ -107,7 +107,7 @@ void ViewshedLocation::connectSignals()
   connect(m_sceneView, &SceneQuickView::mousePressedAndHeld, this, [this](QMouseEvent& event)
   {
     if (!m_locationViewshed)
-      createViewshed(event.pos().x(), event.pos().y());
+      createViewshed(event.position().x(), event.position().y());
 
     m_calculating = true;
   });
@@ -116,7 +116,7 @@ void ViewshedLocation::connectSignals()
   {
     if (m_calculating)
     {
-      const Point pt = m_sceneView->screenToBaseSurface(event.pos().x(), event.pos().y());
+      const Point pt = m_sceneView->screenToBaseSurface(event.position().x(), event.position().y());
       m_locationViewshed->setLocation(pt);
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
@@ -112,7 +112,7 @@ void IdentifyGraphics::connectSignals()
     constexpr bool returnPopupsOnly = false;
     constexpr int maximumResults = 1;
 
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maximumResults);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
   });
 
   // connect to the identifyLayerCompleted signal on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=IdentifyGraphics, Category=DisplayInformation]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file IdentifyGraphics.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -112,7 +124,7 @@ void IdentifyGraphics::connectSignals()
     constexpr bool returnPopupsOnly = false;
     constexpr int maximumResults = 1;
 
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maximumResults);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
   });
 
   // connect to the identifyLayerCompleted signal on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file IdentifyGraphics.cpp
+// [WriteFile Name=IdentifyGraphics, Category=DisplayInformation]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -124,7 +112,7 @@ void IdentifyGraphics::connectSignals()
     constexpr bool returnPopupsOnly = false;
     constexpr int maximumResults = 1;
 
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maximumResults);
   });
 
   // connect to the identifyLayerCompleted signal on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/README.md
@@ -17,7 +17,7 @@ Select a graphic to identify it. You will see an alert message displayed.
 1. Create a `GraphicsOverlay` and add it to the `MapView`.
 2. Add a `Graphic` along with a `SimpleFillSymbol` to the graphics overlay.
 3. Create a `Point` from the location clicked on the map view by the user from the `MapQuickView::mouseClicked` signal.
-4. Identify the graphic on the map view with `identifyGraphicsOverlay(graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, max results)`.
+4. Identify the graphic on the map view with `identifyGraphicsOverlay(graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, max results)`.
 
 ## Relevant API
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file QueryFeaturesWithArcadeExpression.cpp
+// [WriteFile Name=QueryFeaturesWithArcadeExpression, Category=DisplayInformation]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,9 +95,9 @@ void QueryFeaturesWithArcadeExpression::setMapView(MapQuickView* mapView)
       m_mapView->calloutData()->setVisible(false);
     m_mapView->calloutData()->setDetail("");
     // Set callout position
-    const Point mapPoint(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
+    const Point mapPoint(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
     m_mapView->calloutData()->setLocation(mapPoint);
-    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), 12, false);
+    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), 12, false);
 
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=QueryFeaturesWithArcadeExpression, Category=DisplayInformation]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file QueryFeaturesWithArcadeExpression.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,9 +107,9 @@ void QueryFeaturesWithArcadeExpression::setMapView(MapQuickView* mapView)
       m_mapView->calloutData()->setVisible(false);
     m_mapView->calloutData()->setDetail("");
     // Set callout position
-    const Point mapPoint(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+    const Point mapPoint(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
     m_mapView->calloutData()->setLocation(mapPoint);
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), 12, false);
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), 12, false);
 
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.cpp
@@ -95,9 +95,9 @@ void QueryFeaturesWithArcadeExpression::setMapView(MapQuickView* mapView)
       m_mapView->calloutData()->setVisible(false);
     m_mapView->calloutData()->setDetail("");
     // Set callout position
-    const Point mapPoint(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+    const Point mapPoint(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
     m_mapView->calloutData()->setLocation(mapPoint);
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), 12, false);
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), 12, false);
 
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ReadSymbolsFromMobileStyle, Category=DisplayInformation]
-// [Legal]
-// Copyright 2019 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ReadSymbolsFromMobileStyle.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -204,7 +216,7 @@ void ReadSymbolsFromMobileStyle::setMapView(MapQuickView* mapView)
     if (!m_currentSymbol)
       return;
 
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     Graphic* graphic = new Graphic(clickedPoint, m_currentSymbol, m_graphicParent.get());
     overlay->graphics()->append(graphic);
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ReadSymbolsFromMobileStyle.cpp
+// [WriteFile Name=ReadSymbolsFromMobileStyle, Category=DisplayInformation]
+// [Legal]
+// Copyright 2019 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -216,7 +204,7 @@ void ReadSymbolsFromMobileStyle::setMapView(MapQuickView* mapView)
     if (!m_currentSymbol)
       return;
 
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
     Graphic* graphic = new Graphic(clickedPoint, m_currentSymbol, m_graphicParent.get());
     overlay->graphics()->append(graphic);
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp
@@ -204,7 +204,7 @@ void ReadSymbolsFromMobileStyle::setMapView(MapQuickView* mapView)
     if (!m_currentSymbol)
       return;
 
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     Graphic* graphic = new Graphic(clickedPoint, m_currentSymbol, m_graphicParent.get());
     overlay->graphics()->append(graphic);
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/README.md
@@ -15,7 +15,7 @@ Tap anywhere on the map. A callout showing the WGS84 coordinates for the tapped 
 ## How it works
 
 1. Listen for `mouseClicked` signal on the map view.
-2. When the user taps, get the tapped location using the mouseEvent x and y coordinates, `MapQuickView::screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())`.
+2. When the user taps, get the tapped location using the mouseEvent x and y coordinates, `MapQuickView::screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())`.
 3. Create a string to display the coordinates; note that latitude and longitude in WGS84 map to the Y and X coordinates.
 4. Create a new callout definition using a title and the coordinate string.
 5. Display the callout by calling `setVisible` and `setLocation` on the `CalloutData`.

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ShowCallout.cpp
+// [WriteFile Name=ShowCallout, Category=DisplayInformation]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,7 +75,7 @@ void ShowCallout::componentComplete()
     else
     {
       // set callout position
-      Point mapPoint(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
+      Point mapPoint(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
       m_mapView->calloutData()->setLocation(mapPoint);
 
       // set detail as coordinates formatted to decimal numbers with precision 2

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ShowCallout, Category=DisplayInformation]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ShowCallout.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,7 +87,7 @@ void ShowCallout::componentComplete()
     else
     {
       // set callout position
-      Point mapPoint(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+      Point mapPoint(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
       m_mapView->calloutData()->setLocation(mapPoint);
 
       // set detail as coordinates formatted to decimal numbers with precision 2

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/ShowCallout.cpp
@@ -75,7 +75,7 @@ void ShowCallout::componentComplete()
     else
     {
       // set callout position
-      Point mapPoint(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+      Point mapPoint(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
       m_mapView->calloutData()->setLocation(mapPoint);
 
       // set detail as coordinates formatted to decimal numbers with precision 2

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
@@ -137,7 +137,7 @@ void ShowPopup::onMouseClicked(QMouseEvent& mouseEvent)
   constexpr bool returnPopupsOnly = false;
   constexpr int maximumResults = 10;
 
-  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maximumResults);
+  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
 
   if (!m_taskWatcher.isValid())
     qWarning() << "Task not valid.";

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ShowPopup.cpp
+// [WriteFile Name=ShowPopup, Category=DisplayInformation]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -149,7 +137,7 @@ void ShowPopup::onMouseClicked(QMouseEvent& mouseEvent)
   constexpr bool returnPopupsOnly = false;
   constexpr int maximumResults = 10;
 
-  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
+  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maximumResults);
 
   if (!m_taskWatcher.isValid())
     qWarning() << "Task not valid.";

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ShowPopup, Category=DisplayInformation]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ShowPopup.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -137,7 +149,7 @@ void ShowPopup::onMouseClicked(QMouseEvent& mouseEvent)
   constexpr bool returnPopupsOnly = false;
   constexpr int maximumResults = 10;
 
-  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maximumResults);
+  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
 
   if (!m_taskWatcher.isValid())
     qWarning() << "Task not valid.";

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=AddFeaturesFeatureService, Category=EditData]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file AddFeaturesFeatureService.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,7 +65,6 @@ namespace
   };
 }
 
-
 AddFeaturesFeatureService::AddFeaturesFeatureService(QObject* parent /* = nullptr */):
   QObject(parent),
   m_map(new Map(BasemapStyle::ArcGISStreets, this))
@@ -100,8 +111,8 @@ void AddFeaturesFeatureService::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // obtain the map point
-    const double screenX = mouseEvent.pos().x();
-    const double screenY = mouseEvent.pos().y();
+    const double screenX = mouseEvent.position().x();
+    const double screenY = mouseEvent.position().y();
     Point newPoint = m_mapView->screenToLocation(screenX, screenY);
 
     // create the feature attributes

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file AddFeaturesFeatureService.cpp
+// [WriteFile Name=AddFeaturesFeatureService, Category=EditData]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,6 +53,7 @@ namespace
   };
 }
 
+
 AddFeaturesFeatureService::AddFeaturesFeatureService(QObject* parent /* = nullptr */):
   QObject(parent),
   m_map(new Map(BasemapStyle::ArcGISStreets, this))
@@ -111,8 +100,8 @@ void AddFeaturesFeatureService::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // obtain the map point
-    const double screenX = mouseEvent.position().x();
-    const double screenY = mouseEvent.position().y();
+    const double screenX = mouseEvent.pos().x();
+    const double screenY = mouseEvent.pos().y();
     Point newPoint = m_mapView->screenToLocation(screenX, screenY);
 
     // create the feature attributes

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/AddFeaturesFeatureService.cpp
@@ -100,8 +100,8 @@ void AddFeaturesFeatureService::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // obtain the map point
-    const double screenX = mouseEvent.pos().x();
-    const double screenY = mouseEvent.pos().y();
+    const double screenX = mouseEvent.position().x();
+    const double screenY = mouseEvent.position().y();
     Point newPoint = m_mapView->screenToLocation(screenX, screenY);
 
     // create the feature attributes

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ContingentValues.cpp
+// [WriteFile Name=ContingentValues, Category=EditData]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -178,7 +166,7 @@ void ContingentValues::createConnections()
 void ContingentValues::createNewEmptyFeature(QMouseEvent& mouseEvent)
 {
   // Create a new empty feature to define attributes for
-  m_newFeature = static_cast<ArcGISFeature*>(m_gdbFeatureTable->createFeature({}, m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()), this));
+  m_newFeature = static_cast<ArcGISFeature*>(m_gdbFeatureTable->createFeature({}, m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()), this));
   m_gdbFeatureTable->addFeature(m_newFeature);
 
   // Show the attribute form interface

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ContingentValues, Category=EditData]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ContingentValues.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -166,7 +178,7 @@ void ContingentValues::createConnections()
 void ContingentValues::createNewEmptyFeature(QMouseEvent& mouseEvent)
 {
   // Create a new empty feature to define attributes for
-  m_newFeature = static_cast<ArcGISFeature*>(m_gdbFeatureTable->createFeature({}, m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()), this));
+  m_newFeature = static_cast<ArcGISFeature*>(m_gdbFeatureTable->createFeature({}, m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()), this));
   m_gdbFeatureTable->addFeature(m_newFeature);
 
   // Show the attribute form interface

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/ContingentValues.cpp
@@ -166,7 +166,7 @@ void ContingentValues::createConnections()
 void ContingentValues::createNewEmptyFeature(QMouseEvent& mouseEvent)
 {
   // Create a new empty feature to define attributes for
-  m_newFeature = static_cast<ArcGISFeature*>(m_gdbFeatureTable->createFeature({}, m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()), this));
+  m_newFeature = static_cast<ArcGISFeature*>(m_gdbFeatureTable->createFeature({}, m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()), this));
   m_gdbFeatureTable->addFeature(m_newFeature);
 
   // Show the attribute form interface

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file DeleteFeaturesFeatureService.cpp
+// [WriteFile Name=DeleteFeaturesFeatureService, Category=EditData]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,8 +105,8 @@ void DeleteFeaturesFeatureService::connectSignals()
     // call identify on the map view
     constexpr double tolerance = 5.0;
     constexpr int maxResults = 1;
-    const double screenX = mouseEvent.position().x();
-    const double screenY = mouseEvent.position().y();
+    const double screenX = mouseEvent.pos().x();
+    const double screenY = mouseEvent.pos().y();
     constexpr bool returnPopupsOnly = false;
     m_mapView->identifyLayer(m_featureLayer, screenX, screenY, tolerance, returnPopupsOnly, maxResults);
     //! [DeleteFeaturesFeatureService identify feature]

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=DeleteFeaturesFeatureService, Category=EditData]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file DeleteFeaturesFeatureService.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,8 +117,8 @@ void DeleteFeaturesFeatureService::connectSignals()
     // call identify on the map view
     constexpr double tolerance = 5.0;
     constexpr int maxResults = 1;
-    const double screenX = mouseEvent.pos().x();
-    const double screenY = mouseEvent.pos().y();
+    const double screenX = mouseEvent.position().x();
+    const double screenY = mouseEvent.position().y();
     constexpr bool returnPopupsOnly = false;
     m_mapView->identifyLayer(m_featureLayer, screenX, screenY, tolerance, returnPopupsOnly, maxResults);
     //! [DeleteFeaturesFeatureService identify feature]

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/DeleteFeaturesFeatureService.cpp
@@ -105,8 +105,8 @@ void DeleteFeaturesFeatureService::connectSignals()
     // call identify on the map view
     constexpr double tolerance = 5.0;
     constexpr int maxResults = 1;
-    const double screenX = mouseEvent.pos().x();
-    const double screenY = mouseEvent.pos().y();
+    const double screenX = mouseEvent.position().x();
+    const double screenY = mouseEvent.position().y();
     constexpr bool returnPopupsOnly = false;
     m_mapView->identifyLayer(m_featureLayer, screenX, screenY, tolerance, returnPopupsOnly, maxResults);
     //! [DeleteFeaturesFeatureService identify feature]

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file EditAndSyncFeatures.cpp
+// [WriteFile Name=EditAndSyncFeatures, Category=EditData]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -144,7 +132,7 @@ void EditAndSyncFeatures::connectSignals()
     {
       if (!m_selectedFeature)
       {
-        m_mapView->identifyLayer(m_map->operationalLayers()->first(), mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+        m_mapView->identifyLayer(m_map->operationalLayers()->first(), mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
       }
       else
       {
@@ -162,7 +150,7 @@ void EditAndSyncFeatures::connectSignals()
         });
 
         // get the point from the mouse point
-        Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+        Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
         m_selectedFeature->setGeometry(mapPoint);
         featureLayer->featureTable()->updateFeature(m_selectedFeature);
       }
@@ -362,3 +350,4 @@ void EditAndSyncFeatures::executeSync()
     emit hideWindow(5000, false);
   }
 }
+

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=EditAndSyncFeatures, Category=EditData]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file EditAndSyncFeatures.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -132,7 +144,7 @@ void EditAndSyncFeatures::connectSignals()
     {
       if (!m_selectedFeature)
       {
-        m_mapView->identifyLayer(m_map->operationalLayers()->first(), mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+        m_mapView->identifyLayer(m_map->operationalLayers()->first(), mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
       }
       else
       {
@@ -150,7 +162,7 @@ void EditAndSyncFeatures::connectSignals()
         });
 
         // get the point from the mouse point
-        Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+        Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
         m_selectedFeature->setGeometry(mapPoint);
         featureLayer->featureTable()->updateFeature(m_selectedFeature);
       }
@@ -350,4 +362,3 @@ void EditAndSyncFeatures::executeSync()
     emit hideWindow(5000, false);
   }
 }
-

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/EditAndSyncFeatures.cpp
@@ -132,7 +132,7 @@ void EditAndSyncFeatures::connectSignals()
     {
       if (!m_selectedFeature)
       {
-        m_mapView->identifyLayer(m_map->operationalLayers()->first(), mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+        m_mapView->identifyLayer(m_map->operationalLayers()->first(), mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
       }
       else
       {
@@ -150,7 +150,7 @@ void EditAndSyncFeatures::connectSignals()
         });
 
         // get the point from the mouse point
-        Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+        Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
         m_selectedFeature->setGeometry(mapPoint);
         featureLayer->featureTable()->updateFeature(m_selectedFeature);
       }

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -117,7 +117,7 @@ void EditFeatureAttachments::connectSignals()
     emit hideWindow();
 
     // call identify on the map view
-    m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   // connect to the viewpoint changed signal on the MapQuickView

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=EditFeatureAttachments, Category=EditData]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file EditFeatureAttachments.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,7 +129,7 @@ void EditFeatureAttachments::connectSignals()
     emit hideWindow();
 
     // call identify on the map view
-    m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   // connect to the viewpoint changed signal on the MapQuickView

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file EditFeatureAttachments.cpp
+// [WriteFile Name=EditFeatureAttachments, Category=EditData]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,7 +117,7 @@ void EditFeatureAttachments::connectSignals()
     emit hideWindow();
 
     // call identify on the map view
-    m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+    m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
   });
 
   // connect to the viewpoint changed signal on the MapQuickView

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file EditFeaturesWithFeatureLinkedAnnotation.cpp
+// [WriteFile Name=EditFeaturesWithFeatureLinkedAnnotation, Category=EditData]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -182,13 +170,13 @@ void EditFeaturesWithFeatureLinkedAnnotation::onMouseClicked(QMouseEvent& mouseE
   if (m_selectedFeature)
   {
     // move feature to clicked locaiton if already selected
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
     moveFeature(clickedPoint);
   }
   else
   {
     // identify and select feature
-    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), 10, false);
+    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), 10, false);
   }
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=EditFeaturesWithFeatureLinkedAnnotation, Category=EditData]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file EditFeaturesWithFeatureLinkedAnnotation.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,13 +182,13 @@ void EditFeaturesWithFeatureLinkedAnnotation::onMouseClicked(QMouseEvent& mouseE
   if (m_selectedFeature)
   {
     // move feature to clicked locaiton if already selected
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     moveFeature(clickedPoint);
   }
   else
   {
     // identify and select feature
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), 10, false);
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), 10, false);
   }
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/EditFeaturesWithFeatureLinkedAnnotation.cpp
@@ -170,13 +170,13 @@ void EditFeaturesWithFeatureLinkedAnnotation::onMouseClicked(QMouseEvent& mouseE
   if (m_selectedFeature)
   {
     // move feature to clicked locaiton if already selected
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     moveFeature(clickedPoint);
   }
   else
   {
     // identify and select feature
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), 10, false);
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), 10, false);
   }
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file EditWithBranchVersioning.cpp
+// [WriteFile Name=EditWithBranchVersioning, Category=EditData]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,13 +130,13 @@ void EditWithBranchVersioning::onMapDoneLoading(const Error& error)
         emit busyChanged();
         return;
       }
-      const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+      const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
       moveFeature(clickedPoint);
     }
     else
     {
       // call identify on the map view
-      m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+      m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=EditWithBranchVersioning, Category=EditData]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file EditWithBranchVersioning.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,13 +142,13 @@ void EditWithBranchVersioning::onMapDoneLoading(const Error& error)
         emit busyChanged();
         return;
       }
-      const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+      const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
       moveFeature(clickedPoint);
     }
     else
     {
       // call identify on the map view
-      m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+      m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
@@ -130,13 +130,13 @@ void EditWithBranchVersioning::onMapDoneLoading(const Error& error)
         emit busyChanged();
         return;
       }
-      const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+      const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
       moveFeature(clickedPoint);
     }
     else
     {
       // call identify on the map view
-      m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+      m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file UpdateAttributesFeatureService.cpp
+// [WriteFile Name=UpdateAttributesFeatureService, Category=EditData]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,7 +111,7 @@ void UpdateAttributesFeatureService::connectSignals()
     emit hideWindow();
 
     // call identify on the map view
-    m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+    m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
   });
 
   // connect to the viewpoint changed signal on the MapQuickView

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=UpdateAttributesFeatureService, Category=EditData]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file UpdateAttributesFeatureService.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,7 +123,7 @@ void UpdateAttributesFeatureService::connectSignals()
     emit hideWindow();
 
     // call identify on the map view
-    m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   // connect to the viewpoint changed signal on the MapQuickView

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.cpp
@@ -111,7 +111,7 @@ void UpdateAttributesFeatureService::connectSignals()
     emit hideWindow();
 
     // call identify on the map view
-    m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   // connect to the viewpoint changed signal on the MapQuickView

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file UpdateGeometryFeatureService.cpp
+// [WriteFile Name=UpdateGeometryFeatureService, Category=EditData]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,7 +97,7 @@ void UpdateGeometryFeatureService::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // get the point from the mouse point
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
 
     // if a feature is already selected, move the selected feature to the new geometry
     if (m_featureSelected)
@@ -132,7 +120,7 @@ void UpdateGeometryFeatureService::connectSignals()
       m_featureLayer->clearSelection();
 
       // call identify on the map view
-      m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+      m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=UpdateGeometryFeatureService, Category=EditData]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file UpdateGeometryFeatureService.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,7 +109,7 @@ void UpdateGeometryFeatureService::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // get the point from the mouse point
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
 
     // if a feature is already selected, move the selected feature to the new geometry
     if (m_featureSelected)
@@ -120,7 +132,7 @@ void UpdateGeometryFeatureService::connectSignals()
       m_featureLayer->clearSelection();
 
       // call identify on the map view
-      m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+      m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/UpdateGeometryFeatureService.cpp
@@ -97,7 +97,7 @@ void UpdateGeometryFeatureService::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // get the point from the mouse point
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
 
     // if a feature is already selected, move the selected feature to the new geometry
     if (m_featureSelected)
@@ -120,7 +120,7 @@ void UpdateGeometryFeatureService::connectSignals()
       m_featureLayer->clearSelection();
 
       // call identify on the map view
-      m_mapView->identifyLayer(m_featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+      m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
@@ -163,7 +163,7 @@ void CreateMobileGeodatabase::addFeature(QMouseEvent& mouseEvent)
   if (!m_featureTable)
     return;
 
-  const Point mousePoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+  const Point mousePoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   QVariantMap attributes = {};
   attributes.insert("collection_timestamp", QDateTime::currentDateTime());
   Feature* feature = m_featureTable->createFeature(attributes, mousePoint, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=CreateMobileGeodatabase, Category=Features]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file CreateMobileGeodatabase.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -163,7 +175,7 @@ void CreateMobileGeodatabase::addFeature(QMouseEvent& mouseEvent)
   if (!m_featureTable)
     return;
 
-  const Point mousePoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+  const Point mousePoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
   QVariantMap attributes = {};
   attributes.insert("collection_timestamp", QDateTime::currentDateTime());
   Feature* feature = m_featureTable->createFeature(attributes, mousePoint, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file CreateMobileGeodatabase.cpp
+// [WriteFile Name=CreateMobileGeodatabase, Category=Features]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -175,7 +163,7 @@ void CreateMobileGeodatabase::addFeature(QMouseEvent& mouseEvent)
   if (!m_featureTable)
     return;
 
-  const Point mousePoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+  const Point mousePoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
   QVariantMap attributes = {};
   attributes.insert("collection_timestamp", QDateTime::currentDateTime());
   Feature* feature = m_featureTable->createFeature(attributes, mousePoint, this);

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file FeatureLayerSelection.cpp
+// [WriteFile Name=FeatureLayerSelection, Category=Features]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,8 +91,8 @@ void FeatureLayerSelection::connectSignals()
     constexpr double tolerance = 22.0;
     constexpr bool returnPopupsOnly = false;
     constexpr int maximumResults = 1000;
-    const double screenX = mouseEvent.position().x();
-    const double screenY = mouseEvent.position().y();
+    const double screenX = mouseEvent.pos().x();
+    const double screenY = mouseEvent.pos().y();
     m_mapView->identifyLayer(m_featureLayer, screenX, screenY, tolerance, returnPopupsOnly, maximumResults);
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=FeatureLayerSelection, Category=Features]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file FeatureLayerSelection.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -91,8 +103,8 @@ void FeatureLayerSelection::connectSignals()
     constexpr double tolerance = 22.0;
     constexpr bool returnPopupsOnly = false;
     constexpr int maximumResults = 1000;
-    const double screenX = mouseEvent.pos().x();
-    const double screenY = mouseEvent.pos().y();
+    const double screenX = mouseEvent.position().x();
+    const double screenY = mouseEvent.position().y();
     m_mapView->identifyLayer(m_featureLayer, screenX, screenY, tolerance, returnPopupsOnly, maximumResults);
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/FeatureLayerSelection.cpp
@@ -91,8 +91,8 @@ void FeatureLayerSelection::connectSignals()
     constexpr double tolerance = 22.0;
     constexpr bool returnPopupsOnly = false;
     constexpr int maximumResults = 1000;
-    const double screenX = mouseEvent.pos().x();
-    const double screenY = mouseEvent.pos().y();
+    const double screenX = mouseEvent.position().x();
+    const double screenY = mouseEvent.position().y();
     m_mapView->identifyLayer(m_featureLayer, screenX, screenY, tolerance, returnPopupsOnly, maximumResults);
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/README.md
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/README.md
@@ -16,7 +16,7 @@ Click on a feature in the map. All features within a given tolerance (in pixels)
 
 1. Create a `ServiceFeatureTable` from a feature service URL.
 2. Create a `FeatureLayer` from the service feature table.
-3. Identify nearby features at the clicked location using `identifyLayer(featureLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly, maxResults)` on the map view.
+3. Identify nearby features at the clicked location using `identifyLayer(featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maxResults)` on the map view.
 4. Select all identified features in the feature layer with `selectFeatures(features)`.
 
 ## Relevant API

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -184,7 +184,7 @@ void ListRelatedFeatures::connectSignals()
     m_relatedFeaturesModel->clear();
 
     // create objects required to do a selection with a query
-    Point clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     double mapTolerance = 10 * m_mapView->unitsPerDIP();
     Envelope envelope = Envelope(clickPoint.x() - mapTolerance,
                                  clickPoint.y() - mapTolerance,

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ListRelatedFeatures, Category=Features]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ListRelatedFeatures.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -173,7 +185,6 @@ void ListRelatedFeatures::connectSignals()
     }
   });
 
-
   // connect to the mouseClicked signal
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
@@ -184,7 +195,7 @@ void ListRelatedFeatures::connectSignals()
     m_relatedFeaturesModel->clear();
 
     // create objects required to do a selection with a query
-    Point clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     double mapTolerance = 10 * m_mapView->unitsPerDIP();
     Envelope envelope = Envelope(clickPoint.x() - mapTolerance,
                                  clickPoint.y() - mapTolerance,

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/ListRelatedFeatures.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ListRelatedFeatures.cpp
+// [WriteFile Name=ListRelatedFeatures, Category=Features]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -185,6 +173,7 @@ void ListRelatedFeatures::connectSignals()
     }
   });
 
+
   // connect to the mouseClicked signal
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
@@ -195,7 +184,7 @@ void ListRelatedFeatures::connectSignals()
     m_relatedFeaturesModel->clear();
 
     // create objects required to do a selection with a query
-    Point clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    Point clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
     double mapTolerance = 10 * m_mapView->unitsPerDIP();
     Envelope envelope = Envelope(clickPoint.x() - mapTolerance,
                                  clickPoint.y() - mapTolerance,

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=Buffer, Category=Geometry]
-// [Legal]
-// Copyright 2022 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file Buffer.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,7 +118,7 @@ void Buffer::setMapView(MapQuickView* mapView)
 void Buffer::onMouseClicked(QMouseEvent& mouse)
 {
   // get the map point from the mouse click
-  const Point point = m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y());
+  const Point point = m_mapView->screenToLocation(mouse.position().x(), mouse.position().y());
 
   // Create a variable to be the buffer size in meters. There are 1609.34 meters in one mile.
   const int bufferInMeters = bufferSize() * 1609.34;

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.cpp
@@ -106,7 +106,7 @@ void Buffer::setMapView(MapQuickView* mapView)
 void Buffer::onMouseClicked(QMouseEvent& mouse)
 {
   // get the map point from the mouse click
-  const Point point = m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y());
+  const Point point = m_mapView->screenToLocation(mouse.position().x(), mouse.position().y());
 
   // Create a variable to be the buffer size in meters. There are 1609.34 meters in one mile.
   const int bufferInMeters = bufferSize() * 1609.34;

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/Buffer.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file Buffer.cpp
+// [WriteFile Name=Buffer, Category=Geometry]
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,7 +106,7 @@ void Buffer::setMapView(MapQuickView* mapView)
 void Buffer::onMouseClicked(QMouseEvent& mouse)
 {
   // get the map point from the mouse click
-  const Point point = m_mapView->screenToLocation(mouse.position().x(), mouse.position().y());
+  const Point point = m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y());
 
   // Create a variable to be the buffer size in meters. There are 1609.34 meters in one mile.
   const int bufferInMeters = bufferSize() * 1609.34;

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ConvexHull, Category=Geometry]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ConvexHull.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -130,7 +142,7 @@ void ConvexHull::getInputs()
   {
     e.accept();
 
-    const Point clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     m_multipointBuilder->points()->addPoint(clickedPoint);
     m_inputsGraphic->setGeometry(m_multipointBuilder->toGeometry());
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.cpp
@@ -130,7 +130,7 @@ void ConvexHull::getInputs()
   {
     e.accept();
 
-    const Point clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     m_multipointBuilder->points()->addPoint(clickedPoint);
     m_inputsGraphic->setGeometry(m_multipointBuilder->toGeometry());
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/ConvexHull.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ConvexHull.cpp
+// [WriteFile Name=ConvexHull, Category=Geometry]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,7 +130,7 @@ void ConvexHull::getInputs()
   {
     e.accept();
 
-    const Point clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    const Point clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     m_multipointBuilder->points()->addPoint(clickedPoint);
     m_inputsGraphic->setGeometry(m_multipointBuilder->toGeometry());
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=FormatCoordinates, Category=Geometry]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file FormatCoordinates.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -180,7 +192,7 @@ void FormatCoordinates::setMapView(MapQuickView* mapView)
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // get the point from the mouse point
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
 
     // using the point, refresh the graphic and the text
     handleLocationUpdate(std::move(mapPoint));

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.cpp
@@ -180,7 +180,7 @@ void FormatCoordinates::setMapView(MapQuickView* mapView)
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // get the point from the mouse point
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
 
     // using the point, refresh the graphic and the text
     handleLocationUpdate(std::move(mapPoint));

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/FormatCoordinates.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file FormatCoordinates.cpp
+// [WriteFile Name=FormatCoordinates, Category=Geometry]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -192,7 +180,7 @@ void FormatCoordinates::setMapView(MapQuickView* mapView)
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // get the point from the mouse point
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
 
     // using the point, refresh the graphic and the text
     handleLocationUpdate(std::move(mapPoint));

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file GeodesicOperations.cpp
+// [WriteFile Name=GeodesicOperations, Category=Geometry]
+// [Legal]
+// Copyright 2018 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,7 +90,7 @@ void GeodesicOperations::componentComplete()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this, nycPoint](QMouseEvent& mouseEvent)
   {
     // re-project the point to match the NYC graphic
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
     const Point destination = geometry_cast<Point>(GeometryEngine::project(clickedPoint, m_nycGraphic->geometry().spatialReference()));
 
     // update the destination graphic
@@ -141,3 +129,4 @@ QString GeodesicOperations::distanceText() const
 {
   return m_distanceText;
 }
+

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=GeodesicOperations, Category=Geometry]
-// [Legal]
-// Copyright 2018 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file GeodesicOperations.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,7 +102,7 @@ void GeodesicOperations::componentComplete()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this, nycPoint](QMouseEvent& mouseEvent)
   {
     // re-project the point to match the NYC graphic
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     const Point destination = geometry_cast<Point>(GeometryEngine::project(clickedPoint, m_nycGraphic->geometry().spatialReference()));
 
     // update the destination graphic
@@ -129,4 +141,3 @@ QString GeodesicOperations::distanceText() const
 {
   return m_distanceText;
 }
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/GeodesicOperations.cpp
@@ -90,7 +90,7 @@ void GeodesicOperations::componentComplete()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this, nycPoint](QMouseEvent& mouseEvent)
   {
     // re-project the point to match the NYC graphic
-    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     const Point destination = geometry_cast<Point>(GeometryEngine::project(clickedPoint, m_nycGraphic->geometry().spatialReference()));
 
     // update the destination graphic

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file NearestVertex.cpp
+// [WriteFile Name=NearestVertex, Category=Geometry]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -155,7 +143,7 @@ void NearestVertex::setupGraphics()
           [nearestVertexGraphic, nearestCoordinateGraphic, polygonBuilder, clickedLocationGraphic, this]
           (QMouseEvent& e)
   {
-    const Point clickedLocation = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     // normalizing the geometry before performing geometric operations
     const Point normalizedPoint = geometry_cast<Point>(GeometryEngine::normalizeCentralMeridian(clickedLocation));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=NearestVertex, Category=Geometry]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file NearestVertex.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,7 +155,7 @@ void NearestVertex::setupGraphics()
           [nearestVertexGraphic, nearestCoordinateGraphic, polygonBuilder, clickedLocationGraphic, this]
           (QMouseEvent& e)
   {
-    const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedLocation = m_mapView->screenToLocation(e.position().x(), e.position().y());
     // normalizing the geometry before performing geometric operations
     const Point normalizedPoint = geometry_cast<Point>(GeometryEngine::normalizeCentralMeridian(clickedLocation));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/NearestVertex.cpp
@@ -143,7 +143,7 @@ void NearestVertex::setupGraphics()
           [nearestVertexGraphic, nearestCoordinateGraphic, polygonBuilder, clickedLocationGraphic, this]
           (QMouseEvent& e)
   {
-    const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedLocation = m_mapView->screenToLocation(e.position().x(), e.position().y());
     // normalizing the geometry before performing geometric operations
     const Point normalizedPoint = geometry_cast<Point>(GeometryEngine::normalizeCentralMeridian(clickedLocation));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ProjectGeometry.cpp
+// [WriteFile Name=ProjectGeometry, Category=Geometry]
+// [Legal]
+// Copyright 2018 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,7 +89,7 @@ void ProjectGeometry::componentComplete()
 void ProjectGeometry::onMouseClicked(QMouseEvent& event)
 {
   // get the mouse click as a point
-  const Point originalPoint = m_mapView->screenToLocation(event.position().x(), event.position().y());
+  const Point originalPoint = m_mapView->screenToLocation(event.pos().x(), event.pos().y());
 
   // show the clicked location on the map with a graphic
   m_inputGraphic->setGeometry(originalPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ProjectGeometry, Category=Geometry]
-// [Legal]
-// Copyright 2018 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ProjectGeometry.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,7 +101,7 @@ void ProjectGeometry::componentComplete()
 void ProjectGeometry::onMouseClicked(QMouseEvent& event)
 {
   // get the mouse click as a point
-  const Point originalPoint = m_mapView->screenToLocation(event.pos().x(), event.pos().y());
+  const Point originalPoint = m_mapView->screenToLocation(event.position().x(), event.position().y());
 
   // show the clicked location on the map with a graphic
   m_inputGraphic->setGeometry(originalPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/ProjectGeometry.cpp
@@ -89,7 +89,7 @@ void ProjectGeometry::componentComplete()
 void ProjectGeometry::onMouseClicked(QMouseEvent& event)
 {
   // get the mouse click as a point
-  const Point originalPoint = m_mapView->screenToLocation(event.pos().x(), event.pos().y());
+  const Point originalPoint = m_mapView->screenToLocation(event.position().x(), event.position().y());
 
   // show the clicked location on the map with a graphic
   m_inputGraphic->setGeometry(originalPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=SpatialRelationships, Category=Geometry]
-// [Legal]
-// Copyright 2018 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file SpatialRelationships.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,13 +157,12 @@ void SpatialRelationships::addPointGraphic()
   m_graphicsOverlay->graphics()->append(m_pointGraphic);
 }
 
-
 void SpatialRelationships::connectSignals()
 {
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // identify graphics
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 1.0 /*tolerance*/, false /*returnPopupsOnly*/);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 1.0 /*tolerance*/, false /*returnPopupsOnly*/);
   });
 
   connect(m_mapView, &MapQuickView::identifyGraphicsOverlayCompleted, this, [this](QUuid, IdentifyGraphicsOverlayResult* rawResult)

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file SpatialRelationships.cpp
+// [WriteFile Name=SpatialRelationships, Category=Geometry]
+// [Legal]
+// Copyright 2018 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -157,12 +145,13 @@ void SpatialRelationships::addPointGraphic()
   m_graphicsOverlay->graphics()->append(m_pointGraphic);
 }
 
+
 void SpatialRelationships::connectSignals()
 {
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // identify graphics
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 1.0 /*tolerance*/, false /*returnPopupsOnly*/);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 1.0 /*tolerance*/, false /*returnPopupsOnly*/);
   });
 
   connect(m_mapView, &MapQuickView::identifyGraphicsOverlayCompleted, this, [this](QUuid, IdentifyGraphicsOverlayResult* rawResult)

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/SpatialRelationships.cpp
@@ -151,7 +151,7 @@ void SpatialRelationships::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // identify graphics
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 1.0 /*tolerance*/, false /*returnPopupsOnly*/);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 1.0 /*tolerance*/, false /*returnPopupsOnly*/);
   });
 
   connect(m_mapView, &MapQuickView::identifyGraphicsOverlayCompleted, this, [this](QUuid, IdentifyGraphicsOverlayResult* rawResult)

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
@@ -114,8 +114,8 @@ void IdentifyKmlFeatures::setMapView(MapQuickView* mapView)
   // identify clicked features
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
-    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
-    m_mapView->identifyLayer(m_forecastLayer, e.pos().x(), e.pos().y(), 15, false);
+    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    m_mapView->identifyLayer(m_forecastLayer, e.position().x(), e.position().y(), 15, false);
   });
 
   emit mapViewChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file IdentifyKmlFeatures.cpp
+// [WriteFile Name=IdentifyKmlFeatures, Category=Layers]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -126,8 +114,8 @@ void IdentifyKmlFeatures::setMapView(MapQuickView* mapView)
   // identify clicked features
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
-    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
-    m_mapView->identifyLayer(m_forecastLayer, e.position().x(), e.position().y(), 15, false);
+    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    m_mapView->identifyLayer(m_forecastLayer, e.pos().x(), e.pos().y(), 15, false);
   });
 
   emit mapViewChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/IdentifyKmlFeatures.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=IdentifyKmlFeatures, Category=Layers]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file IdentifyKmlFeatures.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,8 +126,8 @@ void IdentifyKmlFeatures::setMapView(MapQuickView* mapView)
   // identify clicked features
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
-    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
-    m_mapView->identifyLayer(m_forecastLayer, e.pos().x(), e.pos().y(), 15, false);
+    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    m_mapView->identifyLayer(m_forecastLayer, e.position().x(), e.position().y(), 15, false);
   });
 
   emit mapViewChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file IdentifyRasterCell.cpp
+// [WriteFile Name=IdentifyRasterCell, Category=Layers]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -157,14 +145,14 @@ void IdentifyRasterCell::connectSignals()
 
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](const QMouseEvent& e)
   {
-    m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
-    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
   });
 
   connect(m_mapView, &MapQuickView::mousePressedAndHeld, this, [this](const QMouseEvent& e)
   {
-    m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
-    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     m_mousePressed = true;
   });
 
@@ -178,8 +166,8 @@ void IdentifyRasterCell::connectSignals()
   {
     if (m_mousePressed)
     {
-      m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
-      m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+      m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
+      m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     }
   });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=IdentifyRasterCell, Category=Layers]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file IdentifyRasterCell.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,14 +157,14 @@ void IdentifyRasterCell::connectSignals()
 
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](const QMouseEvent& e)
   {
-    m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
-    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
   });
 
   connect(m_mapView, &MapQuickView::mousePressedAndHeld, this, [this](const QMouseEvent& e)
   {
-    m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
-    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     m_mousePressed = true;
   });
 
@@ -166,8 +178,8 @@ void IdentifyRasterCell::connectSignals()
   {
     if (m_mousePressed)
     {
-      m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
-      m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+      m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
+      m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     }
   });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/IdentifyRasterCell.cpp
@@ -145,14 +145,14 @@ void IdentifyRasterCell::connectSignals()
 
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](const QMouseEvent& e)
   {
-    m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
-    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
   });
 
   connect(m_mapView, &MapQuickView::mousePressedAndHeld, this, [this](const QMouseEvent& e)
   {
-    m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
-    m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     m_mousePressed = true;
   });
 
@@ -166,8 +166,8 @@ void IdentifyRasterCell::connectSignals()
   {
     if (m_mousePressed)
     {
-      m_mapView->identifyLayer(m_rasterLayer, e.pos().x(), e.pos().y(), 10, false, 1);
-      m_clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+      m_mapView->identifyLayer(m_rasterLayer, e.position().x(), e.position().y(), 10, false, 1);
+      m_clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     }
   });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file IdentifyLayers.cpp
+// [WriteFile Name=IdentifyLayers, Category=Maps]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,7 +110,7 @@ void IdentifyLayers::connectSignals()
     const double tolerance = 12.0;
     const bool returnPopups = false;
     const int maxResults = 10;
-    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups, maxResults);
+    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups, maxResults);
   });
 
   // handle the identify results

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
@@ -110,7 +110,7 @@ void IdentifyLayers::connectSignals()
     const double tolerance = 12.0;
     const bool returnPopups = false;
     const int maxResults = 10;
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups, maxResults);
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups, maxResults);
   });
 
   // handle the identify results

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/IdentifyLayers.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=IdentifyLayers, Category=Maps]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file IdentifyLayers.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,7 +122,7 @@ void IdentifyLayers::connectSignals()
     const double tolerance = 12.0;
     const bool returnPopups = false;
     const int maxResults = 10;
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups, maxResults);
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups, maxResults);
   });
 
   // handle the identify results

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=MobileMap_SearchAndRoute, Category=Maps]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file MobileMap_SearchAndRoute.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,10 +182,10 @@ void MobileMap_SearchAndRoute::connectSignals()
   {
     if (m_currentLocatorTask)
     {
-      m_clickedPoint = Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+      m_clickedPoint = Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
 
       // determine if user clicked on a graphic
-      m_mapView->identifyGraphicsOverlay(m_stopsGraphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 2);
+      m_mapView->identifyGraphicsOverlay(m_stopsGraphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 2);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
@@ -170,10 +170,10 @@ void MobileMap_SearchAndRoute::connectSignals()
   {
     if (m_currentLocatorTask)
     {
-      m_clickedPoint = Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+      m_clickedPoint = Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
 
       // determine if user clicked on a graphic
-      m_mapView->identifyGraphicsOverlay(m_stopsGraphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 2);
+      m_mapView->identifyGraphicsOverlay(m_stopsGraphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 2);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/MobileMap_SearchAndRoute.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file MobileMap_SearchAndRoute.cpp
+// [WriteFile Name=MobileMap_SearchAndRoute, Category=Maps]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -182,10 +170,10 @@ void MobileMap_SearchAndRoute::connectSignals()
   {
     if (m_currentLocatorTask)
     {
-      m_clickedPoint = Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
+      m_clickedPoint = Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
 
       // determine if user clicked on a graphic
-      m_mapView->identifyGraphicsOverlay(m_stopsGraphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 2);
+      m_mapView->identifyGraphicsOverlay(m_stopsGraphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 2);
     }
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ClosestFacility.cpp
+// [WriteFile Name=FindClosestFacilityToAnIncidentInteractive, Category=Routing]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -239,7 +227,7 @@ void ClosestFacility::setupRouting()
     if (busy())
       return;
 
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
     Point incidentPoint(mapPoint.x(), mapPoint.y(), SpatialReference::webMercator());
 
     m_incidentGraphic->setGeometry(incidentPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=FindClosestFacilityToAnIncidentInteractive, Category=Routing]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ClosestFacility.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -227,7 +239,7 @@ void ClosestFacility::setupRouting()
     if (busy())
       return;
 
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     Point incidentPoint(mapPoint.x(), mapPoint.y(), SpatialReference::webMercator());
 
     m_incidentGraphic->setGeometry(incidentPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/ClosestFacility.cpp
@@ -227,7 +227,7 @@ void ClosestFacility::setupRouting()
     if (busy())
       return;
 
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     Point incidentPoint(mapPoint.x(), mapPoint.y(), SpatialReference::webMercator());
 
     m_incidentGraphic->setGeometry(incidentPoint);

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file OfflineRouting.cpp
+// [WriteFile Name=OfflineRouting, Category=Routing]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -207,7 +195,7 @@ void OfflineRouting::connectSignals()
 
   // check whether mouse pressed over an existing stop
   connect(m_mapView, &MapQuickView::mousePressed, this, [this](QMouseEvent& e){
-    m_mapView->identifyGraphicsOverlay(m_stopsOverlay, e.position().x(), e.position().y(), 10, false);
+    m_mapView->identifyGraphicsOverlay(m_stopsOverlay, e.pos().x(), e.pos().y(), 10, false);
   });
 
   // get stops from clicked locations
@@ -215,7 +203,7 @@ void OfflineRouting::connectSignals()
     if (!m_selectedGraphic)
     {
       // return if point is outside of bounds
-      if (!GeometryEngine::within(m_mapView->screenToLocation(e.position().x(), e.position().y()), m_routableArea))
+      if (!GeometryEngine::within(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), m_routableArea))
       {
         qWarning() << "Outside of routable area.";
         return;
@@ -223,7 +211,7 @@ void OfflineRouting::connectSignals()
       TextSymbol* textSymbol = new TextSymbol(QString::number(m_stopsOverlay->graphics()->size() + 1), Qt::white, 20, HorizontalAlignment::Center, VerticalAlignment::Bottom, this);
       textSymbol->setOffsetY(m_pinSymbol->height() / 2);
       CompositeSymbol* stopLabel = new CompositeSymbol(QList<Symbol*>{m_pinSymbol, textSymbol}, this);
-      Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.position().x(), e.position().y()), stopLabel, this);
+      Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), stopLabel, this);
       m_stopsOverlay->graphics()->append(stopGraphic);
       findRoute();
     }
@@ -246,12 +234,12 @@ void OfflineRouting::connectSignals()
       e.accept();
 
       // return if point is outside of bounds
-      if (!GeometryEngine::within(m_mapView->screenToLocation(e.position().x(), e.position().y()), m_routableArea))
+      if (!GeometryEngine::within(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), m_routableArea))
       {
         qWarning() << "Outside of routable area.";
         return;
       }
-      m_selectedGraphic->setGeometry(m_mapView->screenToLocation(e.position().x(), e.position().y()));
+      m_selectedGraphic->setGeometry(m_mapView->screenToLocation(e.pos().x(), e.pos().y()));
       findRoute();
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=OfflineRouting, Category=Routing]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file OfflineRouting.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,7 +207,7 @@ void OfflineRouting::connectSignals()
 
   // check whether mouse pressed over an existing stop
   connect(m_mapView, &MapQuickView::mousePressed, this, [this](QMouseEvent& e){
-    m_mapView->identifyGraphicsOverlay(m_stopsOverlay, e.pos().x(), e.pos().y(), 10, false);
+    m_mapView->identifyGraphicsOverlay(m_stopsOverlay, e.position().x(), e.position().y(), 10, false);
   });
 
   // get stops from clicked locations
@@ -203,7 +215,7 @@ void OfflineRouting::connectSignals()
     if (!m_selectedGraphic)
     {
       // return if point is outside of bounds
-      if (!GeometryEngine::within(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), m_routableArea))
+      if (!GeometryEngine::within(m_mapView->screenToLocation(e.position().x(), e.position().y()), m_routableArea))
       {
         qWarning() << "Outside of routable area.";
         return;
@@ -211,7 +223,7 @@ void OfflineRouting::connectSignals()
       TextSymbol* textSymbol = new TextSymbol(QString::number(m_stopsOverlay->graphics()->size() + 1), Qt::white, 20, HorizontalAlignment::Center, VerticalAlignment::Bottom, this);
       textSymbol->setOffsetY(m_pinSymbol->height() / 2);
       CompositeSymbol* stopLabel = new CompositeSymbol(QList<Symbol*>{m_pinSymbol, textSymbol}, this);
-      Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), stopLabel, this);
+      Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.position().x(), e.position().y()), stopLabel, this);
       m_stopsOverlay->graphics()->append(stopGraphic);
       findRoute();
     }
@@ -234,12 +246,12 @@ void OfflineRouting::connectSignals()
       e.accept();
 
       // return if point is outside of bounds
-      if (!GeometryEngine::within(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), m_routableArea))
+      if (!GeometryEngine::within(m_mapView->screenToLocation(e.position().x(), e.position().y()), m_routableArea))
       {
         qWarning() << "Outside of routable area.";
         return;
       }
-      m_selectedGraphic->setGeometry(m_mapView->screenToLocation(e.pos().x(), e.pos().y()));
+      m_selectedGraphic->setGeometry(m_mapView->screenToLocation(e.position().x(), e.position().y()));
       findRoute();
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.cpp
@@ -195,7 +195,7 @@ void OfflineRouting::connectSignals()
 
   // check whether mouse pressed over an existing stop
   connect(m_mapView, &MapQuickView::mousePressed, this, [this](QMouseEvent& e){
-    m_mapView->identifyGraphicsOverlay(m_stopsOverlay, e.pos().x(), e.pos().y(), 10, false);
+    m_mapView->identifyGraphicsOverlay(m_stopsOverlay, e.position().x(), e.position().y(), 10, false);
   });
 
   // get stops from clicked locations
@@ -203,7 +203,7 @@ void OfflineRouting::connectSignals()
     if (!m_selectedGraphic)
     {
       // return if point is outside of bounds
-      if (!GeometryEngine::within(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), m_routableArea))
+      if (!GeometryEngine::within(m_mapView->screenToLocation(e.position().x(), e.position().y()), m_routableArea))
       {
         qWarning() << "Outside of routable area.";
         return;
@@ -211,7 +211,7 @@ void OfflineRouting::connectSignals()
       TextSymbol* textSymbol = new TextSymbol(QString::number(m_stopsOverlay->graphics()->size() + 1), Qt::white, 20, HorizontalAlignment::Center, VerticalAlignment::Bottom, this);
       textSymbol->setOffsetY(m_pinSymbol->height() / 2);
       CompositeSymbol* stopLabel = new CompositeSymbol(QList<Symbol*>{m_pinSymbol, textSymbol}, this);
-      Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), stopLabel, this);
+      Graphic* stopGraphic = new Graphic(m_mapView->screenToLocation(e.position().x(), e.position().y()), stopLabel, this);
       m_stopsOverlay->graphics()->append(stopGraphic);
       findRoute();
     }
@@ -234,12 +234,12 @@ void OfflineRouting::connectSignals()
       e.accept();
 
       // return if point is outside of bounds
-      if (!GeometryEngine::within(m_mapView->screenToLocation(e.pos().x(), e.pos().y()), m_routableArea))
+      if (!GeometryEngine::within(m_mapView->screenToLocation(e.position().x(), e.position().y()), m_routableArea))
       {
         qWarning() << "Outside of routable area.";
         return;
       }
-      m_selectedGraphic->setGeometry(m_mapView->screenToLocation(e.pos().x(), e.pos().y()));
+      m_selectedGraphic->setGeometry(m_mapView->screenToLocation(e.position().x(), e.position().y()));
       findRoute();
     }
   });

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.cpp
@@ -142,7 +142,7 @@ void RouteAroundBarriers::connectRouteSignals()
 
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
-    const Point clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     if (m_addStops)
     {
       // add stop to list of stops

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=RouteAroundBarriers, Category=Routing]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file RouteAroundBarriers.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,7 +154,7 @@ void RouteAroundBarriers::connectRouteSignals()
 
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
-    const Point clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
     if (m_addStops)
     {
       // add stop to list of stops

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file RouteAroundBarriers.cpp
+// [WriteFile Name=RouteAroundBarriers, Category=Routing]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,7 +142,7 @@ void RouteAroundBarriers::connectRouteSignals()
 
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
-    const Point clickedPoint = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    const Point clickedPoint = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     if (m_addStops)
     {
       // add stop to list of stops

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ServiceArea.cpp
+// [WriteFile Name=ServiceArea, Category=Routing]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -304,7 +292,7 @@ void ServiceArea::setupRouting()
 
     setBusy(true);
 
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
     Point projectedPoint(mapPoint.x(), mapPoint.y(), SpatialReference::webMercator());
 
     if (m_mode == SampleMode::Barrier)

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
@@ -292,7 +292,7 @@ void ServiceArea::setupRouting()
 
     setBusy(true);
 
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     Point projectedPoint(mapPoint.x(), mapPoint.y(), SpatialReference::webMercator());
 
     if (m_mode == SampleMode::Barrier)

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ServiceArea, Category=Routing]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ServiceArea.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -292,7 +304,7 @@ void ServiceArea::setupRouting()
 
     setBusy(true);
 
-    Point mapPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    Point mapPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
     Point projectedPoint(mapPoint.x(), mapPoint.y(), SpatialReference::webMercator());
 
     if (m_mode == SampleMode::Barrier)

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.cpp
@@ -110,7 +110,7 @@ void GetElevationAtPoint::setSceneView(SceneQuickView* sceneView)
 void GetElevationAtPoint::displayElevationOnClick(QMouseEvent& mouseEvent)
 {
   // Convert clicked screen position to position on the map surface.
-  const Point baseSurfacePos = m_sceneView->screenToBaseSurface(mouseEvent.pos().x(), mouseEvent.pos().y());
+  const Point baseSurfacePos = m_sceneView->screenToBaseSurface(mouseEvent.position().x(), mouseEvent.position().y());
 
   // Connect to callback for elevation query, which places marker and sets elevation
   connect(m_scene->baseSurface(), &Surface::locationToElevationCompleted,

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file GetElevationAtPoint.cpp
+// [WriteFile Name=GetElevationAtPoint, Category=Scenes]
+// [Legal]
+// Copyright 2019 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,7 +110,7 @@ void GetElevationAtPoint::setSceneView(SceneQuickView* sceneView)
 void GetElevationAtPoint::displayElevationOnClick(QMouseEvent& mouseEvent)
 {
   // Convert clicked screen position to position on the map surface.
-  const Point baseSurfacePos = m_sceneView->screenToBaseSurface(mouseEvent.position().x(), mouseEvent.position().y());
+  const Point baseSurfacePos = m_sceneView->screenToBaseSurface(mouseEvent.pos().x(), mouseEvent.pos().y());
 
   // Connect to callback for elevation query, which places marker and sets elevation
   connect(m_scene->baseSurface(), &Surface::locationToElevationCompleted,

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/GetElevationAtPoint.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=GetElevationAtPoint, Category=Scenes]
-// [Legal]
-// Copyright 2019 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file GetElevationAtPoint.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,7 +122,7 @@ void GetElevationAtPoint::setSceneView(SceneQuickView* sceneView)
 void GetElevationAtPoint::displayElevationOnClick(QMouseEvent& mouseEvent)
 {
   // Convert clicked screen position to position on the map surface.
-  const Point baseSurfacePos = m_sceneView->screenToBaseSurface(mouseEvent.pos().x(), mouseEvent.pos().y());
+  const Point baseSurfacePos = m_sceneView->screenToBaseSurface(mouseEvent.position().x(), mouseEvent.position().y());
 
   // Connect to callback for elevation query, which places marker and sets elevation
   connect(m_scene->baseSurface(), &Surface::locationToElevationCompleted,

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
@@ -122,7 +122,7 @@ void SceneLayerSelection::connectSignals()
     m_sceneLayer->clearSelection();
 
     // identify from the click
-    m_sceneView->identifyLayer(m_sceneLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 10, false);
+    m_sceneView->identifyLayer(m_sceneLayer, mouseEvent.position().x(), mouseEvent.position().y(), 10, false);
   });
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=SceneLayerSelection, Category=Scenes]
-// [Legal]
-// Copyright 2018 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file SceneLayerSelection.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -122,7 +134,6 @@ void SceneLayerSelection::connectSignals()
     m_sceneLayer->clearSelection();
 
     // identify from the click
-    m_sceneView->identifyLayer(m_sceneLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 10, false);
+    m_sceneView->identifyLayer(m_sceneLayer, mouseEvent.position().x(), mouseEvent.position().y(), 10, false);
   });
 }
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/SceneLayerSelection.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file SceneLayerSelection.cpp
+// [WriteFile Name=SceneLayerSelection, Category=Scenes]
+// [Legal]
+// Copyright 2018 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -134,6 +122,7 @@ void SceneLayerSelection::connectSignals()
     m_sceneLayer->clearSelection();
 
     // identify from the click
-    m_sceneView->identifyLayer(m_sceneLayer, mouseEvent.position().x(), mouseEvent.position().y(), 10, false);
+    m_sceneView->identifyLayer(m_sceneLayer, mouseEvent.pos().x(), mouseEvent.pos().y(), 10, false);
   });
 }
+

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file FindAddress.cpp
+// [WriteFile Name=FindAddress, Category=Search]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,11 +119,11 @@ void FindAddress::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // set the properties for qml
-    m_mapView->calloutData()->setLocation(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
+    m_mapView->calloutData()->setLocation(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
     emit hideCallout();
 
     // call identify on the map view
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
   });
 
   // connect to the identifyGraphicsOverlayCompleted signal on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=FindAddress, Category=Search]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file FindAddress.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -119,11 +131,11 @@ void FindAddress::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // set the properties for qml
-    m_mapView->calloutData()->setLocation(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+    m_mapView->calloutData()->setLocation(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
     emit hideCallout();
 
     // call identify on the map view
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   // connect to the identifyGraphicsOverlayCompleted signal on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/FindAddress.cpp
@@ -119,11 +119,11 @@ void FindAddress::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
     // set the properties for qml
-    m_mapView->calloutData()->setLocation(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y()));
+    m_mapView->calloutData()->setLocation(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y()));
     emit hideCallout();
 
     // call identify on the map view
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   // connect to the identifyGraphicsOverlayCompleted signal on the map view

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=FindPlace, Category=Search]
-// [Legal]
-// Copyright 2017 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file FindPlace.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -125,7 +137,7 @@ void FindPlace::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
     emit hideCallout();
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, e.pos().x(), e.pos().y(), 5, false, 1);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, e.position().x(), e.position().y(), 5, false, 1);
   });
 
   // handle the result once identify completes

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
@@ -125,7 +125,7 @@ void FindPlace::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
     emit hideCallout();
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, e.pos().x(), e.pos().y(), 5, false, 1);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, e.position().x(), e.position().y(), 5, false, 1);
   });
 
   // handle the result once identify completes

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/FindPlace.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file FindPlace.cpp
+// [WriteFile Name=FindPlace, Category=Search]
+// [Legal]
+// Copyright 2017 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -137,7 +125,7 @@ void FindPlace::connectSignals()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
     emit hideCallout();
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, e.position().x(), e.position().y(), 5, false, 1);
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, e.pos().x(), e.pos().y(), 5, false, 1);
   });
 
   // handle the result once identify completes

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file OfflineGeocode.cpp
+// [WriteFile Name=OfflineGeocode, Category=Search]
+// [Legal]
+// Copyright 2016 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -203,8 +191,8 @@ void OfflineGeocode::connectSignals()
   connect(m_mapView, &MapQuickView::errorOccurred, this, &OfflineGeocode::logError);
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
-    m_clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
   });
 
   connect(m_mapView, &MapQuickView::mousePressedAndHeld, this, [this](QMouseEvent& mouseEvent)
@@ -213,7 +201,7 @@ void OfflineGeocode::connectSignals()
     m_isReverseGeocode = true;
 
     // reverse geocode
-    m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())), m_reverseGeocodeParameters);
+    m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())), m_reverseGeocodeParameters);
 
     // make busy indicator visible
     m_geocodeInProgress = true;
@@ -225,7 +213,7 @@ void OfflineGeocode::connectSignals()
     // if user is dragging mouse hold, realtime reverse geocode
     if (m_isPressAndHold)
     {
-      m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())), m_reverseGeocodeParameters);
+      m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())), m_reverseGeocodeParameters);
 
       m_geocodeInProgress = true;
       emit geocodeInProgressChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=OfflineGeocode, Category=Search]
-// [Legal]
-// Copyright 2016 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file OfflineGeocode.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -191,8 +203,8 @@ void OfflineGeocode::connectSignals()
   connect(m_mapView, &MapQuickView::errorOccurred, this, &OfflineGeocode::logError);
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
-    m_clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   connect(m_mapView, &MapQuickView::mousePressedAndHeld, this, [this](QMouseEvent& mouseEvent)
@@ -201,7 +213,7 @@ void OfflineGeocode::connectSignals()
     m_isReverseGeocode = true;
 
     // reverse geocode
-    m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())), m_reverseGeocodeParameters);
+    m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())), m_reverseGeocodeParameters);
 
     // make busy indicator visible
     m_geocodeInProgress = true;
@@ -213,7 +225,7 @@ void OfflineGeocode::connectSignals()
     // if user is dragging mouse hold, realtime reverse geocode
     if (m_isPressAndHold)
     {
-      m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())), m_reverseGeocodeParameters);
+      m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())), m_reverseGeocodeParameters);
 
       m_geocodeInProgress = true;
       emit geocodeInProgressChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -191,8 +191,8 @@ void OfflineGeocode::connectSignals()
   connect(m_mapView, &MapQuickView::errorOccurred, this, &OfflineGeocode::logError);
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& mouseEvent)
   {
-    m_clickedPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.pos().x(), mouseEvent.pos().y(), 5, false, 1);
+    m_clickedPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_mapView->identifyGraphicsOverlay(m_graphicsOverlay, mouseEvent.position().x(), mouseEvent.position().y(), 5, false, 1);
   });
 
   connect(m_mapView, &MapQuickView::mousePressedAndHeld, this, [this](QMouseEvent& mouseEvent)
@@ -201,7 +201,7 @@ void OfflineGeocode::connectSignals()
     m_isReverseGeocode = true;
 
     // reverse geocode
-    m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())), m_reverseGeocodeParameters);
+    m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())), m_reverseGeocodeParameters);
 
     // make busy indicator visible
     m_geocodeInProgress = true;
@@ -213,7 +213,7 @@ void OfflineGeocode::connectSignals()
     // if user is dragging mouse hold, realtime reverse geocode
     if (m_isPressAndHold)
     {
-      m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y())), m_reverseGeocodeParameters);
+      m_locatorTask->reverseGeocodeWithParameters(Point(m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y())), m_reverseGeocodeParameters);
 
       m_geocodeInProgress = true;
       emit geocodeInProgressChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file ReverseGeocodeOnline.cpp
+// [WriteFile Name=ReverseGeocodeOnline, Category=Search]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,7 +80,7 @@ void ReverseGeocodeOnline::getAddress()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
     e.accept();
-    const Point clickedLocation = m_mapView->screenToLocation(e.position().x(), e.position().y());
+    const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
     ReverseGeocodeParameters reverseGeocodeParameters;
     reverseGeocodeParameters.setOutputSpatialReference(m_mapView->spatialReference());
     m_locatorTask->reverseGeocodeWithParameters(clickedLocation, reverseGeocodeParameters);

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=ReverseGeocodeOnline, Category=Search]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file ReverseGeocodeOnline.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,7 +92,7 @@ void ReverseGeocodeOnline::getAddress()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
     e.accept();
-    const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedLocation = m_mapView->screenToLocation(e.position().x(), e.position().y());
     ReverseGeocodeParameters reverseGeocodeParameters;
     reverseGeocodeParameters.setOutputSpatialReference(m_mapView->spatialReference());
     m_locatorTask->reverseGeocodeWithParameters(clickedLocation, reverseGeocodeParameters);

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/ReverseGeocodeOnline.cpp
@@ -80,7 +80,7 @@ void ReverseGeocodeOnline::getAddress()
   connect(m_mapView, &MapQuickView::mouseClicked, this, [this](QMouseEvent& e)
   {
     e.accept();
-    const Point clickedLocation = m_mapView->screenToLocation(e.pos().x(), e.pos().y());
+    const Point clickedLocation = m_mapView->screenToLocation(e.position().x(), e.position().y());
     ReverseGeocodeParameters reverseGeocodeParameters;
     reverseGeocodeParameters.setOutputSpatialReference(m_mapView->spatialReference());
     m_locatorTask->reverseGeocodeWithParameters(clickedLocation, reverseGeocodeParameters);

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file DisplayContentOfUtilityNetworkContainer.cpp
+// [WriteFile Name=DisplayContentOfUtilityNetworkContainer, Category=UtilityNetwork]
+// [Legal]
+// Copyright 2021 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -166,7 +154,7 @@ void DisplayContentOfUtilityNetworkContainer::identifyFeaturesAtMouseClick(QMous
   constexpr double tolerance = 5;
   constexpr bool returnPopupsOnly = false;
 
-  m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly);
+  m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly);
 }
 
 void DisplayContentOfUtilityNetworkContainer::getUtilityAssociationsOfFeature(QUuid, QList<IdentifyLayerResult*> identifyResults)

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
@@ -154,7 +154,7 @@ void DisplayContentOfUtilityNetworkContainer::identifyFeaturesAtMouseClick(QMous
   constexpr double tolerance = 5;
   constexpr bool returnPopupsOnly = false;
 
-  m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly);
+  m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly);
 }
 
 void DisplayContentOfUtilityNetworkContainer::getUtilityAssociationsOfFeature(QUuid, QList<IdentifyLayerResult*> identifyResults)

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=DisplayContentOfUtilityNetworkContainer, Category=UtilityNetwork]
-// [Legal]
-// Copyright 2021 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file DisplayContentOfUtilityNetworkContainer.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -154,7 +166,7 @@ void DisplayContentOfUtilityNetworkContainer::identifyFeaturesAtMouseClick(QMous
   constexpr double tolerance = 5;
   constexpr bool returnPopupsOnly = false;
 
-  m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopupsOnly);
+  m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly);
 }
 
 void DisplayContentOfUtilityNetworkContainer::getUtilityAssociationsOfFeature(QUuid, QList<IdentifyLayerResult*> identifyResults)

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -170,8 +170,8 @@ void PerformValveIsolationTrace::setMapView(MapQuickView* mapView)
 
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
-    m_clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups);
+    m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups);
   });
 
   // handle the identify resultss

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file PerformValveIsolationTrace.cpp
+// [WriteFile Name=PerformValveIsolationTrace, Category=UtilityNetwork]
+// [Legal]
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -182,8 +170,8 @@ void PerformValveIsolationTrace::setMapView(MapQuickView* mapView)
 
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
-    m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
-    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups);
+    m_clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups);
   });
 
   // handle the identify resultss

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=PerformValveIsolationTrace, Category=UtilityNetwork]
-// [Legal]
-// Copyright 2020 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file PerformValveIsolationTrace.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -170,8 +182,8 @@ void PerformValveIsolationTrace::setMapView(MapQuickView* mapView)
 
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
-    m_clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups);
+    m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups);
   });
 
   // handle the identify resultss

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -181,8 +181,8 @@ void TraceUtilityNetwork::connectSignals()
 
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
-    m_clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups);
+    m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups);
   });
 
   // handle the identify results

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -1,6 +1,18 @@
-// [WriteFile Name=TraceUtilityNetwork, Category=UtilityNetwork]
-// [Legal]
-// Copyright 2019 Esri.
+
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file TraceUtilityNetwork.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -181,8 +193,8 @@ void TraceUtilityNetwork::connectSignals()
 
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
-    m_clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
-    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups);
+    m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
+    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups);
   });
 
   // handle the identify results

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -1,18 +1,6 @@
-
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file TraceUtilityNetwork.cpp
+// [WriteFile Name=TraceUtilityNetwork, Category=UtilityNetwork]
+// [Legal]
+// Copyright 2019 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -193,8 +181,8 @@ void TraceUtilityNetwork::connectSignals()
 
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
-    m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
-    m_mapView->identifyLayers(mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopups);
+    m_clickPoint = m_mapView->screenToLocation(mouseEvent.pos().x(), mouseEvent.pos().y());
+    m_mapView->identifyLayers(mouseEvent.pos().x(), mouseEvent.pos().y(), tolerance, returnPopups);
   });
 
   // handle the identify results


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Updates deprecated `MouseEvent.pos()` methods to `MouseEvent.position()`

## Type of change

- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
