### PR TITLE
Tan11389/navigate route fix

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
@@ -16,10 +16,12 @@
 
 import QtQuick
 import QtQuick.Controls
-import Esri.ArcGISRuntime
 import QtQuick.Layouts
 import QtPositioning
-import Esri.Samples
+import Esri.ArcGISRuntime
+
+// QTextToSpeech is not supported by Qt 6.2 so this is commented out
+// import Esri.samples
 
 Rectangle {
     id: rootRectangle

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
@@ -1,18 +1,4 @@
-// COPYRIGHT 2023 ESRI
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file main.cpp
+// Copyright 2020 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
@@ -1,4 +1,18 @@
-// Copyright 2020 Esri.
+// COPYRIGHT 2023 ESRI
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file main.cpp
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +65,7 @@ int main(int argc, char *argv[])
   view.setResizeMode(QQuickView::SizeRootObjectToView);
 
   // Register the C++ NavigateRouteSpeaker class
+  // -- QTextToSpeech is not supported by Qt 6.2, so this is commented out --
   // qmlRegisterType<NavigateRouteSpeaker>("Esri.samples", 1, 0, "NavigateRouteSpeaker");
 
   // Add the import Path


### PR DESCRIPTION
# Description

Comments out `Esri.samples` because the QTextToSpeech-based class registered to it is not supported

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement