### PR TITLE
The path of least resistance.

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/iOS/Info.plist
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/iOS/Info.plist
@@ -53,7 +53,7 @@
         </dict>
     </dict>
     <key>CFBundleIdentifier</key>
-    <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+    <string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/iOS/Info.plist
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/iOS/Info.plist
@@ -53,7 +53,7 @@
         </dict>
     </dict>
     <key>CFBundleIdentifier</key>
-    <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+    <string>com.yourcompany.${PRODUCT_NAME:rfc1034identifier}</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>


### PR DESCRIPTION
Revert back to com.yourcompany. We have some entry in our provisioning profile somewhere such that we get never-ending build problems with `com.esri`. The build is internal for testing, so the name isn't all that important.