### PR TITLE
removed Qt::AA_UseOpenGLES

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
@@ -47,11 +47,6 @@ int main(int argc, char *argv[])
       QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
   }
 
-#ifdef Q_OS_WIN
-  // Force usage of OpenGL ES through ANGLE on Windows
-  QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
-#endif
-
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);


### PR DESCRIPTION
# Description

Found one usage of `Qt::AA_UseOpenGLES` in the samples!

issue: https://devtopia.esri.com/runtime/qt-common/issues/7981