### PR TITLE
Revert remove enum from search

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchBar.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SearchBar.qml
@@ -19,6 +19,7 @@ import QtQuick.Controls
 TextField {
     id: searchBar
     rightPadding: height
+    inputMethodHints: Qt.ImhNoPredictiveText
     selectByMouse: true
 
     Image {


### PR DESCRIPTION
Reverts removing the "ImhNoPredictiveText" enum from the samples search view from this PR: https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/1583

Removing the enum did not fix the automation bugs