### PR TITLE
Fix property name

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/ShowCallout.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/ShowCallout.qml
@@ -73,10 +73,9 @@ Rectangle {
 
         // display callout on mouseClicked
         onMouseClicked: mouse => {
-            if (callout.calloutVisible)
-                callout.dismiss()
-            else
-            {
+            if (callout.visible) {
+                callout.dismiss();
+            } else {
                 calloutLocation = mouse.mapPoint;
                 xCoor = mouse.mapPoint.x.toFixed(2);
                 yCoor = mouse.mapPoint.y.toFixed(2);


### PR DESCRIPTION
# Description

With the C++ sample, when you click the map, if the callout is visible, the callout is hidden, and if it is not visible, then the callout is displayed at that location. With the QML sample, the callout is dismissed and shown at the new location with each map click. This is because the sample is checking for `callout.calloutVisible` but `calloutVisible` isn't a valid property of `Callout`, it should just be `visible`.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] macOS