### PR TITLE
Add clarifying comment

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/FeatureLayer_Selection.qml
@@ -88,6 +88,10 @@ Rectangle {
         }
 
         onIdentifyLayerStatusChanged: {
+            // When MapView.identifyLayerWithMaxResults completes,
+            // it will populate the MapView.identifyLayerResult property
+            // with an IdentifyLayerResult object that we can utilize
+
             if (identifyLayerStatus === Enums.TaskStatusCompleted) {
                 // clear any previous selections
                 featureLayer.clearSelection();


### PR DESCRIPTION
# Description

Adds a comment that clarifies where `identifyLayerResult` comes from, in response to user feedback.