### PR TITLE
Add Ok button to Cpp Identify Graphics

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qml
@@ -44,6 +44,7 @@ IdentifyGraphicsSample {
         modal: true
         x: Math.round(parent.width - width) / 2
         y: Math.round(parent.height - height) / 2
+        standardButtons: Dialog.Ok
         Text {
             text: "Tapped on graphic"
         }


### PR DESCRIPTION
# Description

The QML implementation has an "ok" button but the C++ implementation does not. The screenshot also has an Ok button. This PR adds that into the implementation.

## Type of change

- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android (Qt 6.2.7, Android 12)
- [ ] Linux
- [x] macOS (Qt 6.2.7, macOS 13.2.1)
- [ ] iOS