### PR TITLE
Access correct property for error message

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/DisplayLayerViewDrawState.qml
@@ -74,7 +74,7 @@ Rectangle {
             id: warningDialog
             anchors.centerIn: parent
             standardButtons: Dialog.Ok
-            visible: warningMessage !== "" ? true : false
+            visible: warningMessage !== ""
             Text {
                 id: warningText
                 text: warningMessage;
@@ -106,7 +106,7 @@ Rectangle {
             }
             if (layerViewState.statusFlags & Enums.LayerViewStatusWarning) {
                 statusStringList.push("Warning");
-                warningMessage = qsTr("Warning message: %1".arg(layerViewState.loadError.message));
+                warningMessage = qsTr("Warning message: %1".arg(layerViewState.error.message));
             }
 
             layerViewStatusRepeater.model = statusStringList;


### PR DESCRIPTION
# Description

The application was trying to get an error message from loadError, which is not a property of LayerViewState--it should just be error. This small change fixes that. I also fixed a redundant logic check.

## Type of change

- [x] Bug fix