### PR TITLE
Tanneryould/sv downloader

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SampleManager.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SampleManager.cpp
@@ -106,6 +106,17 @@ void SampleManager::createAndSetTempDirForLocalServer()
 #endif
 }
 
+void SampleManager::setCancelDownload(bool cancel)
+{
+  m_cancelDownload = cancel;
+  emit cancelDownloadChanged();
+}
+
+void SampleManager::setDownloadFailed(bool didFail)
+{
+  m_downloadFailed = didFail;
+  emit downloadFailedChanged();
+}
 // Build the Categories List
 void SampleManager::buildCategoriesList()
 {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SampleManager.h
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/SampleManager.h
@@ -52,6 +52,8 @@ class SampleManager : public QObject
   Q_PROPERTY(bool downloadInProgress READ downloadInProgress WRITE setDownloadInProgress NOTIFY downloadInProgressChanged)
   Q_PROPERTY(QString downloadText READ downloadText WRITE setDownloadText NOTIFY downloadTextChanged)
   Q_PROPERTY(double downloadProgress READ downloadProgress WRITE setDownloadProgress NOTIFY downloadProgressChanged)
+  Q_PROPERTY(bool cancelDownload READ cancelDownload WRITE setCancelDownload NOTIFY cancelDownloadChanged)
+  Q_PROPERTY(bool downloadFailed READ downloadFailed WRITE setDownloadFailed NOTIFY downloadFailedChanged)
 
 public:
   explicit SampleManager(QObject* parent = nullptr);
@@ -77,11 +79,13 @@ public:
 
 signals:
   void sampleInitComplete();
+  void cancelDownloadChanged();
   void currentModeChanged();
   void currentSampleChanged();
   void currentCategoryChanged();
   void currentSourceCodeChanged();
   void doneDownloadingChanged();
+  void downloadFailedChanged();
   void downloadInProgressChanged();
   void downloadTextChanged();
   void downloadProgressChanged();
@@ -117,6 +121,10 @@ private:
   void setDownloadText(const QString& downloadText);
   double downloadProgress() const { return m_downloadProgress; }
   void createAndSetTempDirForLocalServer();
+  bool cancelDownload() const { return m_cancelDownload; }
+  void setCancelDownload(bool cancel);
+  bool downloadFailed() const { return m_downloadFailed; }
+  void setDownloadFailed(bool didFail);
 
 private:
   CategoryListModel* m_categories = nullptr;
@@ -132,6 +140,8 @@ private:
   QString m_downloadText = QString("Downloading");
   double m_downloadProgress = 0.0;
   std::unique_ptr<QTemporaryDir> m_tempDir;
+  bool m_cancelDownload = false;
+  bool m_downloadFailed = false;
 };
 
 #endif // SAMPLEMANAGER_H

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloadView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloadView.qml
@@ -48,7 +48,13 @@ Page {
         }
 
         Label {
-            text: qsTr("This sample uses offline data that is not detected on your system. Press the 'Download' button to download the data to your device.")
+            text: {
+                if (SampleManager.downloadFailed) {
+                    SampleManager.downloadText;
+                } else {
+                    "This sample uses offline data that is not detected on your system. Press the 'Download' button to download the data to your device.";
+                }
+            }
             Layout.preferredWidth: parent.width
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
@@ -61,7 +67,7 @@ Page {
         }
 
         Button {
-            text: (dataDownloadLoader.item && dataDownloadLoader.item.failedToDownload) ? qsTr("Retry") : qsTr("Download")
+            text: (SampleManager.downloadFailed) ? qsTr("Retry") : qsTr("Download")
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             visible: !SampleManager.downloadInProgress
             onClicked: {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloadView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloadView.qml
@@ -48,13 +48,7 @@ Page {
         }
 
         Label {
-            text: {
-                if (SampleManager.downloadFailed) {
-                    SampleManager.downloadText;
-                } else {
-                    "This sample uses offline data that is not detected on your system. Press the 'Download' button to download the data to your device.";
-                }
-            }
+            text:  SampleManager.downloadFailed ? SampleManager.downloadText : "This sample uses offline data that is not detected on your system. Press the 'Download' button to download the data to your device."
             Layout.preferredWidth: parent.width
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DataDownloader.qml
@@ -92,6 +92,11 @@ Item {
     }
 
     function downloadNextItem() {
+        if (SampleManager.cancelDownload) {
+            downloadQueue = [];
+            SampleManager.cancelDownload = false;
+        }
+
         if (downloadQueue.length > 0) {
             SampleManager.downloadInProgress = true;
             const count = downloadQueue.length;
@@ -118,6 +123,8 @@ Item {
 
         function onDownloadDataFailed(itemId) {
             SampleManager.downloadText = "Download failed for item " + itemId;
+            SampleManager.downloadFailed = true;
+            SampleManager.downloadInProgress = false;
         }
 
         function onUnzipFile(filePath, extractPath) {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ManageOfflineDataView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ManageOfflineDataView.qml
@@ -132,7 +132,6 @@ Page {
             visible: SampleManager.downloadInProgress
             enabled: !SampleManager.cancelDownload
             onClicked: {
-                console.log("attempting to cancel download");
                 SampleManager.cancelDownload = true;
             }
             clip: true

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ManageOfflineDataView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/ManageOfflineDataView.qml
@@ -25,6 +25,11 @@ Page {
     visible: SampleManager.currentMode === SampleManager.ManageOfflineDataView
     property bool manageOfflineDataViewDownloadInProgress: false
 
+    onVisibleChanged: {
+        if (!manageOfflineDataViewPage.visible && SampleManager.downloadInProgress)
+            SampleManager.cancelDownload = true;
+    }
+
     FileFolder {
         id: fileFolder
     }
@@ -50,14 +55,15 @@ Page {
             }
             Layout.fillWidth: true
             clip: true
-            visible: SampleManager.downloadInProgress && SampleManager.currentMode
+            visible: SampleManager.downloadInProgress
         }
 
         Button {
-            text: qsTr("Download all offline data")
+            text: SampleManager.downloadFailed ?  "Retry download all offline data" : "Download all offline data"
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             visible: !SampleManager.downloadInProgress
             onClicked: {
+                SampleManager.downloadFailed = false;
                 if (System.reachability === System.ReachabilityOnline || System.reachability === System.ReachabilityUnknown) {
                     allDataDownloadLoader.item.downloadAllDataItems();
                     manageOfflineDataViewDownloadInProgress = true;
@@ -89,7 +95,7 @@ Page {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             Layout.fillWidth: true
             horizontalAlignment: Label.AlignHCenter
-            visible: SampleManager.downloadInProgress || (allDataDownloadLoader.item && allDataDownloadLoader.item.failedToDownload)
+            visible: SampleManager.downloadInProgress || SampleManager.downloadFailed
             font {
                 family: fontFamily
             }
@@ -116,6 +122,19 @@ Page {
             to: 100
             value: SampleManager.downloadProgress
             visible: SampleManager.downloadInProgress
+            clip: true
+        }
+
+        Button {
+            // PortalItem::fetchData does not have a cancel method so we can only clear the remaining items from the download queue
+            text: SampleManager.cancelDownload ? "Cancelling remaining downloads..." : "Cancel remaining downloads"
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            visible: SampleManager.downloadInProgress
+            enabled: !SampleManager.cancelDownload
+            onClicked: {
+                console.log("attempting to cancel download");
+                SampleManager.cancelDownload = true;
+            }
             clip: true
         }
     }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -308,12 +308,12 @@ ApplicationWindow {
     // set the Loader's source and set the description text to the converted markdown
     function showSample() {
         if (SampleManager.currentSample) {
+            descriptionView.descriptionText = SampleManager.currentSample.description;
             if (checkDataItems()) {
                 if (SampleManager.currentMode === SampleManager.ManageOfflineDataView || SampleManager.currentMode === SampleManager.DownloadDataView)
                     SampleManager.currentMode = SampleManager.LiveSampleView;
 
                 liveSample.source = SampleManager.currentSample.source;
-                descriptionView.descriptionText = SampleManager.currentSample.description;
             } else {
                 if (SampleManager.downloadInProgress)
                     SampleManager.currentMode = SampleManager.ManageOfflineDataView;

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -271,31 +271,7 @@ ApplicationWindow {
                 SampleManager.currentMode = SampleManager.NetworkRequiredView;
                 return;
             // If the sample requires offline data
-            } else if (SampleManager.currentSample.dataItems.size > 0) {
-                // If the data already exists, show the sample
-                if (checkDataItems()) {
-                    if (SampleManager.downloadInProgress) {
-                        if (dataDownloadView.pageDownloadInProgress) {
-                            SampleManager.currentMode = SampleManager.DownloadDataView;
-                            return;
-                        } else {
-                            showSample();
-                            return;
-                        }
-                    }
-                    showSample();
-                }
-                // Else, download the data
-                else {
-                    if (SampleManager.downloadInProgress && manageOfflineDataView.manageOfflineDataViewDownloadInProgress)
-                        SampleManager.currentMode = SampleManager.ManageOfflineDataView;
-                    else
-                        SampleManager.currentMode = SampleManager.DownloadDataView;
-                }
-                return;
             } else {
-                if (SampleManager.currentMode ===  SampleManager.DownloadDataView || SampleManager.currentMode === SampleManager.ManageOfflineDataView)
-                    SampleManager.currentMode = SampleManager.LiveSampleView;
                 showSample();
             }
         }
@@ -318,8 +294,14 @@ ApplicationWindow {
         }
 
         function onDoneDownloadingChanged() {
-            SampleManager.currentMode = SampleManager.LiveSampleView;
             showSample();
+        }
+
+        function onCurrentModeChanged() {
+            console.log("current mode changed:",
+                        ["LiveSampleView","SourceCodeView","DescriptionView","ManageOfflineDataView","NetworkRequiredView","DownloadDataView"][SampleManager.currentMode])
+            if (SampleManager.currentMode === SampleManager.LiveSampleView)
+                showSample();
         }
     }
 
@@ -327,9 +309,11 @@ ApplicationWindow {
     function showSample() {
         if (SampleManager.currentSample) {
             if (checkDataItems()) {
+                if (SampleManager.currentMode === SampleManager.ManageOfflineDataView || SampleManager.currentMode === SampleManager.DownloadDataView)
+                    SampleManager.currentMode = SampleManager.LiveSampleView;
+
                 liveSample.source = SampleManager.currentSample.source;
                 descriptionView.descriptionText = SampleManager.currentSample.description;
-                SampleManager.currentMode = SampleManager.LiveSampleView;
             } else {
                 if (SampleManager.downloadInProgress)
                     SampleManager.currentMode = SampleManager.ManageOfflineDataView;

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -298,8 +298,6 @@ ApplicationWindow {
         }
 
         function onCurrentModeChanged() {
-            console.log("current mode changed:",
-                        ["LiveSampleView","SourceCodeView","DescriptionView","ManageOfflineDataView","NetworkRequiredView","DownloadDataView"][SampleManager.currentMode])
             if (SampleManager.currentMode === SampleManager.LiveSampleView)
                 showSample();
         }


### PR DESCRIPTION
# Description

This PR adds the following:

- A cancel button to the "Offline Data Manager View" that allows the user to cancel any remaining downloads in the queue. Previously, if the user clicked "download all offline data" it would begin the download and the only way to cancel would be to close the application. Even if you close the data download manager view, the next sample that would require offline data would just show the offline download in progress.
- If a download fails, it will display the item id that failed, and a retry button. Previously a failed download would also prevent the user from downloading other offline data afterwards because the app state would get stuck on that download failed page. Now it'll be able to download other offline data even after a failed download.
- It also moves the line to propagate the description view to before the check to see if all offline data for a sample is present, so a user can see a sample's description even if they haven't downloaded the offline data.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
