### PR TITLE
Correctly handle exceptions raised when checking README title, description, and screenshot

### DIFF
--- a/Scripts/CI/README_Metadata_StyleCheck/entry.py
+++ b/Scripts/CI/README_Metadata_StyleCheck/entry.py
@@ -342,7 +342,7 @@ class READMEFile:
             self.title = header[0][2:]
             self.description, self.screenshot = header[1].split("\n![]") # This doesn't work if screenshot is formatted improperly.
         except Exception as e:
-            return f"Title, description, or screenshot.png formatted incorrectly. README check cannot proceed.\nFatal error: {e}"
+            raise Exception(f"Title, description, or screenshot.png formatted incorrectly. README check cannot proceed.\nFatal error: {e}")
 
         # If all goes well, the only sections remaining in the text begin with h2's (## )
         for section in text:


### PR DESCRIPTION
# Description
If there are errors in the title, description, or screenshot of a `README.md` file, the python script used to check the README file does not handle the exception and exit the script. The script continues causing an unrelated message to appear, which is confusing. This PR ensures the exception is handled properly and a relevant error message appears.

## Steps to reproduce:

- Working on `v.next` (or a branch created from `v.next`), open the `README.md` for any sample (e.g. `...\ArcGISRuntimeSDKQt_QMLSamples\Maps\DisplayMap\README.md`).
- Change the screenshot reference from `![](screenshot.png)` to `![some words](screenshot.png)` (**note:** this is deemed an invalid format for the screenshot, so the check script should fail). 
- Save the file.
- In a git bash, `cd` into the `...\Scripts\CI\README_Metadata_StyleCheck` folder.
- Run the style checker script referencing the `README.md` file changed above (e.g. `python entry.py -s C:/applications/qt/samples/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.md`).
- The output from the script is shown below. The message is unrelated to the formatting problem we introduced above (i.e. incorrect format for the screenshot reference):
```
Found 2 errors in file:
C:/applications/qt/samples/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.md
1. Missing essential headers: ['Use case', 'How to use the sample', 'How it works', 'Relevant API', 'Tags']. (This may be due to improper capitalization).
2. Section headers are not in the correct order.
Expected order to be: ['Use case', 'How to use the sample', 'How it works', 'Relevant API', 'Offline data', 'About the data', 'Additional information', 'Tags'].
```

- If the script is run with the proposed change, the below message is printed, which is more helpful:
```
Found 1 errors in file:
C:/applications/qt/samples/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.md
1. Error checking C:/applications/qt/samples/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/README.md. Exception: Title, description, or screenshot.png formatted incorrectly. README check cannot proceed.
Fatal error: not enough values to unpack (expected 2, got 1)
```

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement