### PR TITLE
Qt 6.5 UI Fixes

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -129,7 +129,7 @@ DisplayGridSample {
             ComboBox {
                 id: gridTypeComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [latlonGrid, mgrsGrid, utmGrid, usngGrid]
@@ -137,7 +137,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metricsGridTypeComboBox.text = model[i];
-                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width + 20);
+                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width);
                     }
                 }
                 TextMetrics {
@@ -181,7 +181,7 @@ DisplayGridSample {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "white", "blue"]
@@ -206,7 +206,7 @@ DisplayGridSample {
             ComboBox {
                 id: colorCombo2
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "black", "blue"]
@@ -214,7 +214,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         colorCombo2Metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width);
                     }
                 }
                 TextMetrics {
@@ -232,7 +232,7 @@ DisplayGridSample {
             ComboBox {
                 id: positionCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [geographicPosition, bottomLeftPosition, bottomRightPosition, topLeftPosition, topRightPosition, centerPosition, allSidesPosition]
@@ -240,7 +240,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         positionComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, positionComboMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, positionComboMetrics.width);
                     }
                 }
                 TextMetrics {
@@ -259,7 +259,7 @@ DisplayGridSample {
             ComboBox {
                 id: formatCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [ddFormat, dmsFormat]
@@ -268,7 +268,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         formatComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, formatComboMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, formatComboMetrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -129,7 +129,7 @@ DisplayGridSample {
             ComboBox {
                 id: gridTypeComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [latlonGrid, mgrsGrid, utmGrid, usngGrid]
@@ -181,7 +181,7 @@ DisplayGridSample {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "white", "blue"]
@@ -206,7 +206,7 @@ DisplayGridSample {
             ComboBox {
                 id: colorCombo2
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "black", "blue"]
@@ -232,7 +232,7 @@ DisplayGridSample {
             ComboBox {
                 id: positionCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [geographicPosition, bottomLeftPosition, bottomRightPosition, topLeftPosition, topRightPosition, centerPosition, allSidesPosition]
@@ -259,7 +259,7 @@ DisplayGridSample {
             ComboBox {
                 id: formatCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [ddFormat, dmsFormat]

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -137,7 +137,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metricsGridTypeComboBox.text = model[i];
-                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width);
+                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width + 20);
                     }
                 }
                 TextMetrics {
@@ -214,7 +214,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         colorCombo2Metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width);
+                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width + 20);
                     }
                 }
                 TextMetrics {
@@ -240,7 +240,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         positionComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, positionComboMetrics.width);
+                        modelWidth = Math.max(modelWidth, positionComboMetrics.width + 20);
                     }
                 }
                 TextMetrics {
@@ -268,7 +268,7 @@ DisplayGridSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         formatComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, formatComboMetrics.width);
+                        modelWidth = Math.max(modelWidth, formatComboMetrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -216,7 +216,7 @@ Item {
             ComboBox {
                 id: typeDmgCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + 20
                 Layout.margins: 5
                 Layout.fillWidth: true
                 enabled: !model.sgdbVersionIsDefault

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -96,7 +96,7 @@ UpdateAttributesFeatureServiceSample {
 
             ComboBox {
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.columnSpan: 2
                 Layout.margins: 5
                 Layout.fillWidth: true

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -105,7 +105,7 @@ UpdateAttributesFeatureServiceSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -96,7 +96,7 @@ UpdateAttributesFeatureServiceSample {
 
             ComboBox {
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.columnSpan: 2
                 Layout.margins: 5
                 Layout.fillWidth: true
@@ -105,7 +105,7 @@ UpdateAttributesFeatureServiceSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml
@@ -59,7 +59,7 @@ Item {
         id: control
         anchors.right: parent.right
         padding: 5
-        width: 110
+        width: 130
 
         background: Rectangle {
             color: "black"
@@ -72,7 +72,6 @@ Item {
                 verticalCenter: parent.verticalCenter
                 horizontalCenter: parent.horizontalCenter
             }
-            spacing: 20
 
             GridLayout {
                 id: geometryColumn
@@ -115,13 +114,6 @@ Item {
                     }
                 }
 
-                Rectangle { // Used to create a space between the point/multipoint and polyline/polygon buttons.
-                    id: spacer
-                    height: 10
-                    opacity: 0
-                    Layout.columnSpan: 2
-                }
-
                 GeometryEditorButton {
                     id: lineButton
                     buttonName: qsTr("Line")
@@ -147,6 +139,15 @@ Item {
                     model: [qsTr("VertexTool"), qsTr("FreehandTool")]
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
+
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 10
+                        // Make the rectangle visible if a dropdown indicator exists
+                        // An indicator only exists if a theme is set
+                        visible: parent.indicator
+                        border.width: 1
+                    }
 
                     onCurrentIndexChanged: {
                         switch (currentIndex) {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateAndEditGeometries/GeometryEditorButton.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateAndEditGeometries/GeometryEditorButton.qml
@@ -1,4 +1,4 @@
-// [WriteFile Name=CreateAndEditGeometries, Category=DisplayInformation]
+// [WriteFile Name=CreateAndEditGeometries, Category=Geometry]
 // [Legal]
 // Copyright 2023 Esri.
 
@@ -27,45 +27,38 @@ RoundButton {
     property string iconPath: ""
 
     Layout.fillWidth: true
-    padding: 0
-
-    background: Rectangle {
-        radius: 5
-        opacity: enabled || checked ? 1 : 0.3
-        color: geometryEditorButton.down ? "#d0d0d0" : "#e0e0e0"
-    }
 
     // Set the focus policy so that the buttons do not take focus from the MapView
     focusPolicy: Qt.NoFocus
 
-    contentItem: Item {
-        Component.onCompleted: {
-            // Calculate content item width & height once component has been instantiated using the image and text.
-            implicitWidth = imgComponent.implicitWidth + textComponent.implicitWidth;
-            implicitHeight = imgComponent.implicitHeight + textComponent.implicitHeight;
-        }
+    radius: 5
 
-        Image {
-            id: imgComponent
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-                verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -textComponent.height/2
-            }
-            source: iconPath
-            width: 20
-            fillMode: Image.PreserveAspectFit
-        }
+    Rectangle {
+        anchors.fill: parent
+        radius: parent.radius
+        opacity: parent.enabled || parent.checked ? 1 : 0.3
+        color: geometryEditorButton.down ? "#d0d0d0" : "#e0e0e0"
+    }
 
-        Text {
-            id: textComponent
-            anchors {
-                top: imgComponent.bottom;
-                horizontalCenter: parent.horizontalCenter
-            }
-            text: buttonName
-            font.pixelSize: 8
+    Image {
+        id: imgComponent
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            verticalCenter: parent.verticalCenter
+            verticalCenterOffset: -textComponent.height/2
         }
+        source: iconPath
+        width: 20
+        fillMode: Image.PreserveAspectFit
+    }
+
+    Text {
+        id: textComponent
+        anchors {
+            top: imgComponent.bottom
+            horizontalCenter: parent.horizontalCenter
+        }
+        text: buttonName
+        font.pixelSize: 8
     }
 }
-

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -59,7 +59,7 @@ SpatialOperationsSample {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width);
+                modelWidth = Math.max(modelWidth, metrics.width + 20);
             }
         }
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -53,13 +53,13 @@ SpatialOperationsSample {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding
+        width: modelWidth + leftPadding + rightPadding + indicator.width
         model: geometryOperations
         onCurrentIndexChanged: applyGeometryOperation(currentIndex);
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width + 20);
+                modelWidth = Math.max(modelWidth, metrics.width);
             }
         }
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -45,6 +45,13 @@ SpatialOperationsSample {
             top: parent.top
             margins: 10
         }
+
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
         model: geometryOperations

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -46,14 +46,18 @@ SpatialOperationsSample {
             margins: 10
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
         model: geometryOperations
         onCurrentIndexChanged: applyGeometryOperation(currentIndex);
         Component.onCompleted : {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -139,7 +139,7 @@ BlendRasterLayerSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {
@@ -162,7 +162,7 @@ BlendRasterLayerSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics2.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics2.width);
+                        modelWidth = Math.max(modelWidth, metrics2.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -132,7 +132,7 @@ BlendRasterLayerSample {
             ComboBox {
                 id: slopeCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel
@@ -155,7 +155,7 @@ BlendRasterLayerSample {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.fillWidth: true
                 textRole: "name"
                 model: colorRampModel

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -132,14 +132,14 @@ BlendRasterLayerSample {
             ComboBox {
                 id: slopeCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {
@@ -155,14 +155,14 @@ BlendRasterLayerSample {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.fillWidth: true
                 textRole: "name"
                 model: colorRampModel
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics2.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics2.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics2.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -66,6 +66,12 @@ Item {
                 Layout.fillWidth: true
                 Layout.margins: 3
                 Layout.alignment: Qt.AlignHCenter
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
             }
 
             Button {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -67,10 +67,14 @@ Item {
                 Layout.margins: 3
                 Layout.alignment: Qt.AlignHCenter
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/ChangeSublayerVisibility.qml
@@ -43,7 +43,7 @@ ChangeSublayerVisibilitySample {
             top: parent.top
         }
         height: 150
-        width: 150
+        width: 170
         color: "transparent"
 
         MouseArea {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
@@ -49,7 +49,7 @@ DisplayKmlSample {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding
+        width: modelWidth + leftPadding + rightPadding + indicator.width
 
         model: ["URL", "Local file", "Portal Item"]
 
@@ -66,7 +66,7 @@ DisplayKmlSample {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width + 20);
+                modelWidth = Math.max(modelWidth, metrics.width);
             }
             currentIndexChanged();
         }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
@@ -66,7 +66,7 @@ DisplayKmlSample {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width);
+                modelWidth = Math.max(modelWidth, metrics.width + 20);
             }
             currentIndexChanged();
         }

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
@@ -42,14 +42,18 @@ DisplayKmlSample {
             margins: 5
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
         model: ["URL", "Local file", "Portal Item"]
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/DisplayKml.qml
@@ -42,6 +42,12 @@ DisplayKmlSample {
             margins: 5
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -99,7 +99,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -90,7 +90,7 @@ Rectangle {
             ComboBox {
                 id: slopeBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: HillshadeSlopeTypeModel{}
@@ -99,7 +99,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -90,7 +90,7 @@ Rectangle {
             ComboBox {
                 id: slopeBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: HillshadeSlopeTypeModel{}

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -60,14 +60,14 @@ RasterRenderingRuleSample {
                 ComboBox {
                     id: renderingRulesCombo
                     property int modelWidth: 0
-                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                     Layout.margins: 10
                     model: renderingRuleNames
 
                     onModelChanged: {
                         for (let i = 0; i < model.length; ++i) {
                             metrics.text = model[i];
-                            modelWidth = Math.max(modelWidth, metrics.width + 20);
+                            modelWidth = Math.max(modelWidth, metrics.width);
                         }
                     }
                     TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -60,7 +60,7 @@ RasterRenderingRuleSample {
                 ComboBox {
                     id: renderingRulesCombo
                     property int modelWidth: 0
-                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                     Layout.margins: 10
                     model: renderingRuleNames
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -67,7 +67,7 @@ RasterRenderingRuleSample {
                     onModelChanged: {
                         for (let i = 0; i < model.length; ++i) {
                             metrics.text = model[i];
-                            modelWidth = Math.max(modelWidth, metrics.width);
+                            modelWidth = Math.max(modelWidth, metrics.width + 20);
                         }
                     }
                     TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -115,7 +115,7 @@ RasterRgbRendererSample {
 
             model: stretchTypes
             property int modelWidth: 0
-            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -119,7 +119,7 @@ RasterRgbRendererSample {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width);
+                    modelWidth = Math.max(modelWidth, metrics.width + 20);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -115,11 +115,11 @@ RasterRgbRendererSample {
 
             model: stretchTypes
             property int modelWidth: 0
-            Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width + 20);
+                    modelWidth = Math.max(modelWidth, metrics.width);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -99,6 +99,13 @@ RasterStretchRendererSample {
                         modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
+
                 TextMetrics {
                     id: metrics
                     font: stretchTypeCombo.font

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -92,7 +92,7 @@ RasterStretchRendererSample {
                 anchors.horizontalCenter: parent.horizontalCenter
                 model: stretchTypes
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
@@ -100,10 +100,14 @@ RasterStretchRendererSample {
                     }
                 }
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
 
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -96,7 +96,7 @@ RasterStretchRendererSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -92,11 +92,11 @@ RasterStretchRendererSample {
                 anchors.horizontalCenter: parent.horizontalCenter
                 model: stretchTypes
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding
+                width: modelWidth + leftPadding + rightPadding + indicator.width
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -43,7 +43,7 @@ VectorTiledLayerUrlSample {
             margins: 15
         }
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding
+        width: modelWidth + leftPadding + rightPadding + indicator.width
 
         // Add background to the ComboBox
         Rectangle {
@@ -60,7 +60,7 @@ VectorTiledLayerUrlSample {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width + 20);
+                modelWidth = Math.max(modelWidth, metrics.width);
             }
         }
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -44,6 +44,13 @@ VectorTiledLayerUrlSample {
         }
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
+
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova","World Street Map (Night)"]
         onCurrentTextChanged: {
             // Call C++ invokable function to switch the basemaps

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -43,12 +43,16 @@ VectorTiledLayerUrlSample {
             margins: 15
         }
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova","World Street Map (Night)"]

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -53,7 +53,7 @@ VectorTiledLayerUrlSample {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width);
+                modelWidth = Math.max(modelWidth, metrics.width + 20);
             }
         }
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
@@ -59,7 +59,7 @@ LocalServerServicesSample {
             ComboBox {
                 id: servicesCombo
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding
+                width: modelWidth + leftPadding + rightPadding + indicator.width
 
                 enabled: isServerRunning
                 model: ["Map Service", "Feature Service", "Geoprocessing Service"]
@@ -71,7 +71,7 @@ LocalServerServicesSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
@@ -71,7 +71,7 @@ LocalServerServicesSample {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
@@ -59,7 +59,7 @@ LocalServerServicesSample {
             ComboBox {
                 id: servicesCombo
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
                 enabled: isServerRunning
                 model: ["Map Service", "Feature Service", "Geoprocessing Service"]

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -32,7 +32,16 @@ Item {
         mapView: view
     }
 
+    // Add a background to the column
+    Rectangle {
+        anchors {
+            fill: col
+        }
+        radius: 10
+    }
+
     Column {
+        id: col
         spacing: 15
         padding: 10
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -36,6 +36,7 @@ Item {
     Rectangle {
         anchors.fill: col
         radius: 10
+        border.width: 1
     }
 
     Column {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -34,9 +34,7 @@ Item {
 
     // Add a background to the column
     Rectangle {
-        anchors {
-            fill: col
-        }
+        anchors.fill: col
         radius: 10
     }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -43,10 +43,14 @@ ChangeViewpointSample {
             margins: 15
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int bestWidth: implicitWidth

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -43,6 +43,12 @@ ChangeViewpointSample {
             margins: 15
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int bestWidth: implicitWidth
 
         width: bestWidth + rightPadding + leftPadding

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -51,7 +51,7 @@ ChangeViewpointSample {
 
         property int bestWidth: implicitWidth
 
-        width: bestWidth + rightPadding + leftPadding
+        width: bestWidth + rightPadding + leftPadding + 20
 
         model: [ "Center",
                  "Center and scale",

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -66,7 +66,7 @@ Rectangle {
                Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -58,7 +58,7 @@ Rectangle {
             ComboBox {
                 id: basemapComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: ["Streets", "Imagery", "Topographic", "Oceans"]

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -58,7 +58,7 @@ Rectangle {
             ComboBox {
                 id: basemapComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: ["Streets", "Imagery", "Topographic", "Oceans"]
@@ -66,7 +66,7 @@ Rectangle {
                Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -84,6 +84,12 @@ Item {
                 model: model.preplannedList
                 textRole: "itemTitle"
                 onActivated: model.checkIfMapExists(preplannedCombo.currentIndex);
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
             }
 
             Button {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -85,10 +85,14 @@ Item {
                 textRole: "itemTitle"
                 onActivated: model.checkIfMapExists(preplannedCombo.currentIndex);
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -205,7 +205,7 @@ Rectangle {
                     horizontalCenter: parent.horizontalCenter
                 }
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 model: [ "No filter", "FLOW < 500", "FLOW < 300", "FLOW < 100" ]
 
                 onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -222,7 +222,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -197,11 +197,6 @@ Rectangle {
                 color: "#474747"
             }
 
-            Rectangle {
-                anchors.fill: filterComboBox
-                color: "white"
-            }
-
             ComboBox {
                 id: filterComboBox
                 anchors {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -205,7 +205,7 @@ Rectangle {
                     horizontalCenter: parent.horizontalCenter
                 }
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding
+                width: modelWidth + leftPadding + rightPadding + indicator.width
                 model: [ "No filter", "FLOW < 500", "FLOW < 300", "FLOW < 100" ]
 
                 onCurrentTextChanged: {
@@ -217,7 +217,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -93,7 +93,7 @@ ManageBookmarksSample {
                 let w = bestWidth;
                 for (let i = 0; i < model.rowCount(); ++i) {
                     metrics.text = manageBookmarksSample.bookmarkNameForIndex(i);
-                    w = Math.max(w, metrics.width);
+                    w = Math.max(w, metrics.width + 20);
                 }
                 bestWidth = w;
             }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -104,6 +104,12 @@ ManageBookmarksSample {
             manageBookmarksSample.goToBookmark(bookmarkComboBox.currentIndex);
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         TextMetrics {
             id: metrics
             font: bookmarkComboBox.font

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -82,7 +82,7 @@ ManageBookmarksSample {
             margins: 15
         }
         property int bestWidth: implicitWidth
-        width: bestWidth + leftPadding + rightPadding + indicator.width
+        width: bestWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
         // Set the model to the BookmarkListModel
         model: manageBookmarksSample.bookmarks
 
@@ -104,10 +104,14 @@ ManageBookmarksSample {
             manageBookmarksSample.goToBookmark(bookmarkComboBox.currentIndex);
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -82,7 +82,7 @@ ManageBookmarksSample {
             margins: 15
         }
         property int bestWidth: implicitWidth
-        width: bestWidth + leftPadding + rightPadding
+        width: bestWidth + leftPadding + rightPadding + indicator.width
         // Set the model to the BookmarkListModel
         model: manageBookmarksSample.bookmarks
 
@@ -93,7 +93,7 @@ ManageBookmarksSample {
                 let w = bestWidth;
                 for (let i = 0; i < model.rowCount(); ++i) {
                     metrics.text = manageBookmarksSample.bookmarkNameForIndex(i);
-                    w = Math.max(w, metrics.width + 20);
+                    w = Math.max(w, metrics.width);
                 }
                 bestWidth = w;
             }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/MapReferenceScale.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/MapReferenceScale.qml
@@ -79,10 +79,14 @@ Item {
                 Component.onCompleted: mapReferenceScaleSampleModel.currentMapScale = referenceScales[scales.currentIndex];
                 onActivated: mapReferenceScaleSampleModel.currentMapScale = referenceScales[scales.currentIndex];
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/MapReferenceScale.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/MapReferenceScale.qml
@@ -78,6 +78,12 @@ Item {
                 model: ["1:500000","1:250000","1:100000","1:50000"]
                 Component.onCompleted: mapReferenceScaleSampleModel.currentMapScale = referenceScales[scales.currentIndex];
                 onActivated: mapReferenceScaleSampleModel.currentMapScale = referenceScales[scales.currentIndex];
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
             }
 
             Button {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -46,10 +46,14 @@ Item {
                 routingModel.findRoute();
             }
 
-            // Add background to the ComboBox
+            // Add a background to the ComboBox
             Rectangle {
                 anchors.fill: parent
                 radius: 10
+                // Make the rectangle visible if a dropdown indicator exists
+                // An indicator only exists if a theme is set
+                visible: parent.indicator
+                border.width: 1
             }
         }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -45,6 +45,12 @@ Item {
                 routingModel.travelModeIndex = currentIndex;
                 routingModel.findRoute();
             }
+
+            // Add background to the ComboBox
+            Rectangle {
+                anchors.fill: parent
+                radius: 10
+            }
         }
 
         Button {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -98,7 +98,7 @@ ServiceAreaSample {
             model: ["Facility", "Barrier"]
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding
+            width: modelWidth + leftPadding + rightPadding + indicator.width
 
             // Add background to the ComboBox
             Rectangle {
@@ -116,7 +116,7 @@ ServiceAreaSample {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width + 20);
+                    modelWidth = Math.max(modelWidth, metrics.width);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -116,7 +116,7 @@ ServiceAreaSample {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width);
+                    modelWidth = Math.max(modelWidth, metrics.width + 20);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -98,12 +98,16 @@ ServiceAreaSample {
             model: ["Facility", "Barrier"]
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding + indicator.width
+            width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
-            // Add background to the ComboBox
+            // Add a background to the ComboBox
             Rectangle {
                 anchors.fill: parent
                 radius: 10
+                // Make the rectangle visible if a dropdown indicator exists
+                // An indicator only exists if a theme is set
+                visible: parent.indicator
+                border.width: 1
             }
 
             onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/ServiceArea.qml
@@ -100,6 +100,12 @@ ServiceAreaSample {
             property int modelWidth: 0
             width: modelWidth + leftPadding + rightPadding
 
+            // Add background to the ComboBox
+            Rectangle {
+                anchors.fill: parent
+                radius: 10
+            }
+
             onCurrentTextChanged: {
                 if (currentText === "Facility")
                     setFacilityMode();

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -65,13 +65,13 @@ Animate3DSymbolsSample {
                 model: missionsModel
                 textRole: "display"
                 property real modelWidth: 0
-                Layout.minimumWidth: leftPadding + rightPadding + modelWidth
+                Layout.minimumWidth: leftPadding + rightPadding + modelWidth + indicator.width
 
                 onModelChanged: {
                     for (let i = 0; i < missionsModel.rowCount(); ++i) {
                         const index = missionsModel.index(i, 0);
                         textMetrics.text = missionsModel.data(index);
-                        modelWidth = Math.max(modelWidth, textMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, textMetrics.width);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -65,7 +65,7 @@ Animate3DSymbolsSample {
                 model: missionsModel
                 textRole: "display"
                 property real modelWidth: 0
-                Layout.minimumWidth: leftPadding + rightPadding + modelWidth + indicator.width
+                Layout.minimumWidth: leftPadding + rightPadding + modelWidth + (indicator ? indicator.width : 10)
 
                 onModelChanged: {
                     for (let i = 0; i < missionsModel.rowCount(); ++i) {
@@ -87,10 +87,14 @@ Animate3DSymbolsSample {
 
                 Component.onCompleted: missionList.currentTextChanged()
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -71,7 +71,7 @@ Animate3DSymbolsSample {
                     for (let i = 0; i < missionsModel.rowCount(); ++i) {
                         const index = missionsModel.index(i, 0);
                         textMetrics.text = missionsModel.data(index);
-                        modelWidth = Math.max(modelWidth, textMetrics.width);
+                        modelWidth = Math.max(modelWidth, textMetrics.width + 20);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -86,6 +86,12 @@ Animate3DSymbolsSample {
                 }
 
                 Component.onCompleted: missionList.currentTextChanged()
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
             }
 
             LabeledSlider {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -64,7 +64,7 @@ FeatureLayerExtrusionSample {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width);
+                    modelWidth = Math.max(modelWidth, metrics.width + 20);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -46,6 +46,12 @@ FeatureLayerExtrusionSample {
             property int modelWidth: 0
             width: modelWidth + leftPadding + rightPadding
 
+            // Add a background to the ComboBox
+            Rectangle {
+                anchors.fill: parent
+                radius: 10
+            }
+
             model: ["TOTAL POPULATION", "POPULATION DENSITY"]
 
             onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -44,7 +44,7 @@ FeatureLayerExtrusionSample {
             }
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding
+            width: modelWidth + leftPadding + rightPadding + indicator.width
 
             // Add a background to the ComboBox
             Rectangle {
@@ -64,7 +64,7 @@ FeatureLayerExtrusionSample {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width + 20);
+                    modelWidth = Math.max(modelWidth, metrics.width);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -44,12 +44,16 @@ FeatureLayerExtrusionSample {
             }
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding + indicator.width
+            width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
             // Add a background to the ComboBox
             Rectangle {
                 anchors.fill: parent
                 radius: 10
+                // Make the rectangle visible if a dropdown indicator exists
+                // An indicator only exists if a theme is set
+                visible: parent.indicator
+                border.width: 1
             }
 
             model: ["TOTAL POPULATION", "POPULATION DENSITY"]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
@@ -126,14 +126,14 @@ Rectangle {
                             id: fieldComboBox
                             anchors.verticalCenter: parent.verticalCenter
                             property int modelWidth: 0
-                            width: modelWidth + leftPadding + rightPadding
+                            width: modelWidth + leftPadding + rightPadding + indicator.width
                             model: fields
                             onModelChanged: {
                                 if (!fields)
                                     return;
                                 for (let i = 0; i < model.length; ++i) {
                                     metricsFieldComboBox.text = model[i];
-                                    modelWidth = Math.max(modelWidth, metricsFieldComboBox.width + 20);
+                                    modelWidth = Math.max(modelWidth, metricsFieldComboBox.width);
                                 }
                             }
                             TextMetrics {
@@ -152,12 +152,12 @@ Rectangle {
                             id: statisticComboBox
                             anchors.verticalCenter: parent.verticalCenter
                             property int modelWidth: 0
-                            width: modelWidth + leftPadding + rightPadding
+                            width: modelWidth + leftPadding + rightPadding + indicator.width
                             model: statisticTypes
                             Component.onCompleted : {
                                 for (let i = 0; i < model.length; ++i) {
                                     metricsStatisticComboBox.text = model[i];
-                                    modelWidth = Math.max(modelWidth, metricsStatisticComboBox.width + 20);
+                                    modelWidth = Math.max(modelWidth, metricsStatisticComboBox.width);
                                 }
                             }
                             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
@@ -133,7 +133,7 @@ Rectangle {
                                     return;
                                 for (let i = 0; i < model.length; ++i) {
                                     metricsFieldComboBox.text = model[i];
-                                    modelWidth = Math.max(modelWidth, metricsFieldComboBox.width);
+                                    modelWidth = Math.max(modelWidth, metricsFieldComboBox.width + 20);
                                 }
                             }
                             TextMetrics {
@@ -157,7 +157,7 @@ Rectangle {
                             Component.onCompleted : {
                                 for (let i = 0; i < model.length; ++i) {
                                     metricsStatisticComboBox.text = model[i];
-                                    modelWidth = Math.max(modelWidth, metricsStatisticComboBox.width);
+                                    modelWidth = Math.max(modelWidth, metricsStatisticComboBox.width + 20);
                                 }
                             }
                             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/OptionsPage.qml
@@ -126,7 +126,7 @@ Rectangle {
                             id: fieldComboBox
                             anchors.verticalCenter: parent.verticalCenter
                             property int modelWidth: 0
-                            width: modelWidth + leftPadding + rightPadding + indicator.width
+                            width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                             model: fields
                             onModelChanged: {
                                 if (!fields)
@@ -152,7 +152,7 @@ Rectangle {
                             id: statisticComboBox
                             anchors.verticalCenter: parent.verticalCenter
                             property int modelWidth: 0
-                            width: modelWidth + leftPadding + rightPadding + indicator.width
+                            width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                             model: statisticTypes
                             Component.onCompleted : {
                                 for (let i = 0; i < model.length; ++i) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -268,7 +268,7 @@ Rectangle {
             ComboBox {
                 id: gridTypeComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [latlonGrid, mgrsGrid, utmGrid, usngGrid]
@@ -362,7 +362,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
@@ -393,7 +393,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo2
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "black", "blue"]
@@ -423,7 +423,7 @@ Rectangle {
             ComboBox {
                 id: positionCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [geographic, bottomLeft, bottomRight, topLeft, topRight, center, allSides]
@@ -455,7 +455,7 @@ Rectangle {
             ComboBox {
                 id: formatCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [dd, dms]

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -301,7 +301,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metricsGridTypeComboBox.text = model[i];
-                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width);
+                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width + 20);
                     }
                 }
                 TextMetrics {
@@ -376,7 +376,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         colorComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, colorComboMetrics.width);
+                        modelWidth = Math.max(modelWidth, colorComboMetrics.width + 20);
                     }
                 }
                 TextMetrics {
@@ -405,7 +405,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         colorCombo2Metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width);
+                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width + 20);
                     }
                 }
                 TextMetrics {
@@ -436,7 +436,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         positionComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, positionComboMetrics.width);
+                        modelWidth = Math.max(modelWidth, positionComboMetrics.width + 20);
                     }
                 }
                 TextMetrics {
@@ -468,7 +468,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         formatComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, formatComboMetrics.width);
+                        modelWidth = Math.max(modelWidth, formatComboMetrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/DisplayGrid.qml
@@ -268,7 +268,7 @@ Rectangle {
             ComboBox {
                 id: gridTypeComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [latlonGrid, mgrsGrid, utmGrid, usngGrid]
@@ -301,7 +301,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metricsGridTypeComboBox.text = model[i];
-                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width + 20);
+                        modelWidth = Math.max(modelWidth, metricsGridTypeComboBox.width);
                     }
                 }
                 TextMetrics {
@@ -362,7 +362,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
 
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
@@ -376,7 +376,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         colorComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, colorComboMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, colorComboMetrics.width);
                     }
                 }
                 TextMetrics {
@@ -393,7 +393,7 @@ Rectangle {
             ComboBox {
                 id: colorCombo2
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: ["red", "black", "blue"]
@@ -405,7 +405,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         colorCombo2Metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, colorCombo2Metrics.width);
                     }
                 }
                 TextMetrics {
@@ -423,7 +423,7 @@ Rectangle {
             ComboBox {
                 id: positionCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [geographic, bottomLeft, bottomRight, topLeft, topRight, center, allSides]
@@ -436,7 +436,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         positionComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, positionComboMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, positionComboMetrics.width);
                     }
                 }
                 TextMetrics {
@@ -455,7 +455,7 @@ Rectangle {
             ComboBox {
                 id: formatCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.rightMargin: 10
                 Layout.fillWidth: true
                 model: [dd, dms]
@@ -468,7 +468,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         formatComboMetrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, formatComboMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, formatComboMetrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -180,7 +180,7 @@ Rectangle {
 
             ComboBox {
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
 
                 Layout.columnSpan: 2
                 Layout.margins: 5
@@ -191,7 +191,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -191,7 +191,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/UpdateAttributesFeatureService.qml
@@ -180,7 +180,7 @@ Rectangle {
 
             ComboBox {
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
                 Layout.columnSpan: 2
                 Layout.margins: 5

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml
@@ -176,7 +176,7 @@ Rectangle {
         id: control
         anchors.right: parent.right
         padding: 5
-        width: 110
+        width: 130
 
         background: Rectangle {
             color: "black"
@@ -189,7 +189,6 @@ Rectangle {
                 verticalCenter: parent.verticalCenter
                 horizontalCenter: parent.horizontalCenter
             }
-            spacing: 20
 
             GridLayout {
                 id: geometryColumn
@@ -232,13 +231,6 @@ Rectangle {
                     }
                 }
 
-                Rectangle { // Used to create a space between the point/multipoint and polyline/polygon buttons.
-                    id: spacer
-                    height: 10
-                    opacity: 0
-                    Layout.columnSpan: 2
-                }
-
                 GeometryEditorButton {
                     id: lineButton
                     buttonName: qsTr("Line")
@@ -262,6 +254,16 @@ Rectangle {
                     model: [qsTr("VertexTool"), qsTr("FreehandTool")]
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
+
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 10
+                        // Make the rectangle visible if a dropdown indicator exists
+                        // An indicator only exists if a theme is set
+                        visible: parent.indicator
+                        border.width: 1
+                    }
+
                     enabled: {
                         if (!geometryEditor.started)
                             false;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/GeometryEditorButton.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/GeometryEditorButton.qml
@@ -27,45 +27,38 @@ RoundButton {
     property string iconPath: ""
 
     Layout.fillWidth: true
-    padding: 0
-
-    background: Rectangle {
-        radius: 5
-        opacity: enabled || checked ? 1 : 0.3
-        color: geometryEditorButton.down ? "#d0d0d0" : "#e0e0e0"
-    }
 
     // Set the focus policy so that the buttons do not take focus from the MapView
     focusPolicy: Qt.NoFocus
 
-    contentItem: Item {
-        Component.onCompleted: {
-            // Calculate content item width & height once component has been instantiated using the image and text.
-            implicitWidth = imgComponent.implicitWidth + textComponent.implicitWidth;
-            implicitHeight = imgComponent.implicitHeight + textComponent.implicitHeight;
-        }
+    radius: 5
 
-        Image {
-            id: imgComponent
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-                verticalCenter: parent.verticalCenter
-                verticalCenterOffset: -textComponent.height/2
-            }
-            source: iconPath
-            width: 20
-            fillMode: Image.PreserveAspectFit
-        }
+    Rectangle {
+        anchors.fill: parent
+        radius: parent.radius
+        opacity: parent.enabled || parent.checked ? 1 : 0.3
+        color: geometryEditorButton.down ? "#d0d0d0" : "#e0e0e0"
+    }
 
-        Text {
-            id: textComponent
-            anchors {
-                top: imgComponent.bottom;
-                horizontalCenter: parent.horizontalCenter
-            }
-            text: buttonName
-            font.pixelSize: 8
+    Image {
+        id: imgComponent
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            verticalCenter: parent.verticalCenter
+            verticalCenterOffset: -textComponent.height/2
         }
+        source: iconPath
+        width: 20
+        fillMode: Image.PreserveAspectFit
+    }
+
+    Text {
+        id: textComponent
+        anchors {
+            top: imgComponent.bottom
+            horizontalCenter: parent.horizontalCenter
+        }
+        text: buttonName
+        font.pixelSize: 8
     }
 }
-

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 #endif
 
   // Set the source
-  view.setSource(QUrl("qrc:/Samples/DisplayInformation/CreateAndEditGeometries/CreateAndEditGeometries.qml"));
+  view.setSource(QUrl("qrc:/Samples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml"));
 
   view.show();
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -83,7 +83,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding
+        width: modelWidth + leftPadding + rightPadding + indicator.width
         model: geometryOperations
 
         onCurrentIndexChanged: applyGeometryOperation(currentIndex);
@@ -91,7 +91,7 @@ Rectangle {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width + 20);
+                modelWidth = Math.max(modelWidth, metrics.width);
             }
         }
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -76,14 +76,18 @@ Rectangle {
             margins: 10
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
         model: geometryOperations
 
         onCurrentIndexChanged: applyGeometryOperation(currentIndex);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/SpatialOperations.qml
@@ -75,6 +75,13 @@ Rectangle {
             top: parent.top
             margins: 10
         }
+
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
         model: geometryOperations
@@ -84,7 +91,7 @@ Rectangle {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width);
+                modelWidth = Math.max(modelWidth, metrics.width + 20);
             }
         }
         TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -168,7 +168,7 @@ Rectangle {
             ComboBox {
                 id: slopeCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -176,7 +176,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/BlendRasterLayer.qml
@@ -168,7 +168,7 @@ Rectangle {
             ComboBox {
                 id: slopeCombo
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.fillWidth: true
                 textRole: "name"
                 model: slopeTypeModel
@@ -176,7 +176,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -83,10 +83,14 @@ Rectangle {
                     Layout.margins: 3
                     Layout.alignment: Qt.AlignHCenter
 
-                    // Add background to the ComboBox
+                    // Add a background to the ComboBox
                     Rectangle {
                         anchors.fill: parent
                         radius: 10
+                        // Make the rectangle visible if a dropdown indicator exists
+                        // An indicator only exists if a theme is set
+                        visible: parent.indicator
+                        border.width: 1
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/BrowseWfsLayers.qml
@@ -82,6 +82,12 @@ Rectangle {
                     Layout.fillWidth: true
                     Layout.margins: 3
                     Layout.alignment: Qt.AlignHCenter
+
+                    // Add background to the ComboBox
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 10
+                    }
                 }
 
                 Button {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
@@ -87,7 +87,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding
+        width: modelWidth + leftPadding + rightPadding + indicator.width
 
         model: ["URL", "Local file", "Portal Item"]
 
@@ -116,7 +116,7 @@ Rectangle {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width + 20);
+                modelWidth = Math.max(modelWidth, metrics.width);
             }
             currentIndexChanged();
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
@@ -80,14 +80,18 @@ Rectangle {
             margins: 5
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
 
         model: ["URL", "Local file", "Portal Item"]
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/DisplayKml.qml
@@ -80,6 +80,12 @@ Rectangle {
             margins: 5
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
 
@@ -110,7 +116,7 @@ Rectangle {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width);
+                modelWidth = Math.max(modelWidth, metrics.width + 20);
             }
             currentIndexChanged();
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -90,7 +90,7 @@ Rectangle {
             ComboBox {
                 id: slopeBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: HillshadeSlopeTypeModel{}
@@ -100,7 +100,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -100,7 +100,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/HillshadeSettings.qml
@@ -90,7 +90,7 @@ Rectangle {
             ComboBox {
                 id: slopeBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: HillshadeSlopeTypeModel{}

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -101,7 +101,7 @@ Rectangle {
                     onModelChanged: {
                         for (let i = 0; i < model.length; ++i) {
                             metrics.text = model[i];
-                            modelWidth = Math.max(modelWidth, metrics.width);
+                            modelWidth = Math.max(modelWidth, metrics.width + 20);
                         }
                     }
                     TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -96,12 +96,12 @@ Rectangle {
                 ComboBox {
                     id: renderingRulesCombo
                     property int modelWidth: 0
-                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                     model: renderingRuleNames
                     onModelChanged: {
                         for (let i = 0; i < model.length; ++i) {
                             metrics.text = model[i];
-                            modelWidth = Math.max(modelWidth, metrics.width + 20);
+                            modelWidth = Math.max(modelWidth, metrics.width);
                         }
                     }
                     TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/RasterRenderingRule.qml
@@ -96,7 +96,7 @@ Rectangle {
                 ComboBox {
                     id: renderingRulesCombo
                     property int modelWidth: 0
-                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                    Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                     model: renderingRuleNames
                     onModelChanged: {
                         for (let i = 0; i < model.length; ++i) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -147,7 +147,7 @@ Rectangle {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width);
+                    modelWidth = Math.max(modelWidth, metrics.width + 20);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -143,7 +143,7 @@ Rectangle {
 
             model: stretchTypes
             property int modelWidth: 0
-            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/RasterRgbRenderer.qml
@@ -143,11 +143,11 @@ Rectangle {
 
             model: stretchTypes
             property int modelWidth: 0
-            Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+            Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width + 20);
+                    modelWidth = Math.max(modelWidth, metrics.width);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -121,10 +121,17 @@ Rectangle {
                 property int modelWidth: 0
                 width: modelWidth + leftPadding + rightPadding
                 model: stretchTypes
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
+
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -119,7 +119,7 @@ Rectangle {
                 id: stretchTypeCombo
                 anchors.horizontalCenter: parent.horizontalCenter
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding
+                width: modelWidth + leftPadding + rightPadding + indicator.width
                 model: stretchTypes
 
                 // Add background to the ComboBox
@@ -131,7 +131,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/RasterStretchRenderer.qml
@@ -119,13 +119,17 @@ Rectangle {
                 id: stretchTypeCombo
                 anchors.horizontalCenter: parent.horizontalCenter
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 model: stretchTypes
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
 
                 Component.onCompleted : {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -57,14 +57,18 @@ Rectangle {
             margins: 15
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding + indicator.width
+        width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova", "World Street Map (Night)"]
         onCurrentTextChanged: {
             // Call this JavaScript function when the current selection changes

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -56,6 +56,13 @@ Rectangle {
             top: parent.top
             margins: 15
         }
+
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova", "World Street Map (Night)"]
@@ -68,7 +75,7 @@ Rectangle {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width);
+                modelWidth = Math.max(modelWidth, metrics.width + 20);
             }
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/VectorTiledLayerUrl.qml
@@ -64,7 +64,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + leftPadding + rightPadding
+        width: modelWidth + leftPadding + rightPadding + indicator.width
         model: ["Mid-Century","Colored Pencil","Newspaper","Nova", "World Street Map (Night)"]
         onCurrentTextChanged: {
             // Call this JavaScript function when the current selection changes
@@ -75,7 +75,7 @@ Rectangle {
         Component.onCompleted : {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width + 20);
+                modelWidth = Math.max(modelWidth, metrics.width);
             }
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -48,7 +48,14 @@ Rectangle {
             }
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: col
+            radius: 10
+        }
+
         Column {
+            id: col
             spacing: 15
             padding: 10
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/BrowseBuildingFloors.qml
@@ -48,10 +48,11 @@ Rectangle {
             }
         }
 
-        // Add background to the ComboBox
+        // Add a background to the Column
         Rectangle {
             anchors.fill: col
             radius: 10
+            border.width: 1
         }
 
         Column {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -70,10 +70,14 @@ Rectangle {
             margins: 5
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/ChangeViewpoint.qml
@@ -70,6 +70,12 @@ Rectangle {
             margins: 5
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + leftPadding + rightPadding
 
@@ -81,7 +87,7 @@ Rectangle {
         Component.onCompleted: {
             for (let i = 0; i < model.length; ++i) {
                 metrics.text = model[i];
-                modelWidth = Math.max(modelWidth, metrics.width)
+                modelWidth = Math.max(modelWidth, metrics.width + 20)
             }
         }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -58,7 +58,7 @@ Rectangle {
             ComboBox {
                 id: basemapComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: ["Streets", "Imagery", "Topographic", "Oceans"]
@@ -66,7 +66,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -66,7 +66,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/LayerWindow.qml
@@ -58,7 +58,7 @@ Rectangle {
             ComboBox {
                 id: basemapComboBox
                 property int modelWidth: 0
-                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + indicator.width
+                Layout.minimumWidth: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 Layout.margins: 5
                 Layout.fillWidth: true
                 model: ["Streets", "Imagery", "Topographic", "Oceans"]

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -233,6 +233,12 @@ Rectangle {
                 model: null
                 textRole: "itemTitle"
 
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
+
                 onActivated: {
                     if (offlineMapTask.preplannedMapAreaList.count <= 0)
                         return;

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/DownloadPreplannedMap.qml
@@ -233,10 +233,14 @@ Rectangle {
                 model: null
                 textRole: "itemTitle"
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
 
                 onActivated: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -206,7 +206,7 @@ Rectangle {
                     horizontalCenter: parent.horizontalCenter
                 }
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding + indicator.width
+                width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
                 model: [ "No filter", "FLOW < 500", "FLOW < 300", "FLOW < 100" ]
 
                 onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -198,11 +198,6 @@ Rectangle {
                 color: "#474747"
             }
 
-            Rectangle {
-                anchors.fill: filterComboBox
-                color: "white"
-            }
-
             ComboBox {
                 id: filterComboBox
                 anchors {
@@ -223,7 +218,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width);
+                        modelWidth = Math.max(modelWidth, metrics.width + 20);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/OverridesWindow.qml
@@ -206,7 +206,7 @@ Rectangle {
                     horizontalCenter: parent.horizontalCenter
                 }
                 property int modelWidth: 0
-                width: modelWidth + leftPadding + rightPadding
+                width: modelWidth + leftPadding + rightPadding + indicator.width
                 model: [ "No filter", "FLOW < 500", "FLOW < 300", "FLOW < 100" ]
 
                 onCurrentTextChanged: {
@@ -218,7 +218,7 @@ Rectangle {
                 Component.onCompleted : {
                     for (let i = 0; i < model.length; ++i) {
                         metrics.text = model[i];
-                        modelWidth = Math.max(modelWidth, metrics.width + 20);
+                        modelWidth = Math.max(modelWidth, metrics.width);
                     }
                 }
                 TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -162,7 +162,7 @@ Rectangle {
         }
 
         property int modelWidth: 0
-        width: modelWidth + rightPadding + leftPadding
+        width: modelWidth + rightPadding + leftPadding + indicator.width
         model: map.bookmarks
 
         Connections {
@@ -173,7 +173,7 @@ Rectangle {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
                         bookmarks.modelWidth = Math.max(bookmarks.modelWidth,
-                                                        metrics.width + 20);
+                                                        metrics.width);
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -155,14 +155,18 @@ Rectangle {
             margins: 5
         }
 
-        // Add background to the ComboBox
+        // Add a background to the ComboBox
         Rectangle {
             anchors.fill: parent
             radius: 10
+            // Make the rectangle visible if a dropdown indicator exists
+            // An indicator only exists if a theme is set
+            visible: parent.indicator
+            border.width: 1
         }
 
         property int modelWidth: 0
-        width: modelWidth + rightPadding + leftPadding + indicator.width
+        width: modelWidth + rightPadding + leftPadding + (indicator ? indicator.width : 10)
         model: map.bookmarks
 
         Connections {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/ManageBookmarks.qml
@@ -155,6 +155,12 @@ Rectangle {
             margins: 5
         }
 
+        // Add background to the ComboBox
+        Rectangle {
+            anchors.fill: parent
+            radius: 10
+        }
+
         property int modelWidth: 0
         width: modelWidth + rightPadding + leftPadding
         model: map.bookmarks
@@ -167,7 +173,7 @@ Rectangle {
                     for (let i = 0; i < model.count; ++i) {
                         metrics.text = model.get(i).name;
                         bookmarks.modelWidth = Math.max(bookmarks.modelWidth,
-                                                        metrics.width);
+                                                        metrics.width + 20);
                     }
                 }
             }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/MapReferenceScale.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/MapReferenceScale.qml
@@ -105,6 +105,12 @@ Rectangle {
                 model: ["1:500000","1:250000","1:100000","1:50000"]
                 Component.onCompleted: applyReferenceScaleToMap();
                 onActivated: applyReferenceScaleToMap();
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
             }
 
             Button {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/MapReferenceScale.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/MapReferenceScale.qml
@@ -106,10 +106,14 @@ Rectangle {
                 Component.onCompleted: applyReferenceScaleToMap();
                 onActivated: applyReferenceScaleToMap();
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
             }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -57,10 +57,14 @@ Rectangle {
                     routeTask.findRoute();
                 }
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
             }
             Button {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/OfflineRouting.qml
@@ -56,6 +56,12 @@ Rectangle {
                 onCurrentIndexChanged: {
                     routeTask.findRoute();
                 }
+
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
             }
             Button {
                 text: "Reset"

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -221,7 +221,7 @@ Rectangle {
         ComboBox {
             id: modeComboBox
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding
+            width: modelWidth + leftPadding + rightPadding + indicator.width
             model: ["Facility", "Barrier"]
 
             // Add background to the ComboBox
@@ -241,7 +241,7 @@ Rectangle {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width + 20);
+                    modelWidth = Math.max(modelWidth, metrics.width);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -221,13 +221,17 @@ Rectangle {
         ComboBox {
             id: modeComboBox
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding + indicator.width
+            width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
             model: ["Facility", "Barrier"]
 
-            // Add background to the ComboBox
+            // Add a background to the ComboBox
             Rectangle {
                 anchors.fill: parent
                 radius: 10
+                // Make the rectangle visible if a dropdown indicator exists
+                // An indicator only exists if a theme is set
+                visible: parent.indicator
+                border.width: 1
             }
 
             onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/ServiceArea.qml
@@ -224,6 +224,12 @@ Rectangle {
             width: modelWidth + leftPadding + rightPadding
             model: ["Facility", "Barrier"]
 
+            // Add background to the ComboBox
+            Rectangle {
+                anchors.fill: parent
+                radius: 10
+            }
+
             onCurrentTextChanged: {
                 if (currentText !== "Barrier")
                     return;
@@ -235,7 +241,7 @@ Rectangle {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width);
+                    modelWidth = Math.max(modelWidth, metrics.width + 20);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -134,7 +134,7 @@ Rectangle {
             ComboBox {
                 id: missionList
                 property real modelWidth: 0
-                Layout.minimumWidth: leftPadding + rightPadding + modelWidth
+                Layout.minimumWidth: leftPadding + rightPadding + modelWidth + indicator.width
                 enabled: !playButton.checked
                 model: missionsModel
                 textRole: "name"
@@ -148,7 +148,7 @@ Rectangle {
                 onModelChanged: {
                     for (let i = 0; i < missionsModel.count; ++i) {
                         textMetrics.text = missionsModel.get(i).name;
-                        modelWidth = Math.max(modelWidth, textMetrics.width + 20);
+                        modelWidth = Math.max(modelWidth, textMetrics.width);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -139,10 +139,16 @@ Rectangle {
                 model: missionsModel
                 textRole: "name"
 
+                // Add background to the ComboBox
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 10
+                }
+
                 onModelChanged: {
                     for (let i = 0; i < missionsModel.count; ++i) {
                         textMetrics.text = missionsModel.get(i).name;
-                        modelWidth = Math.max(modelWidth, textMetrics.width);
+                        modelWidth = Math.max(modelWidth, textMetrics.width + 20);
                     }
                 }
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/Animate3DSymbols.qml
@@ -134,15 +134,19 @@ Rectangle {
             ComboBox {
                 id: missionList
                 property real modelWidth: 0
-                Layout.minimumWidth: leftPadding + rightPadding + modelWidth + indicator.width
+                Layout.minimumWidth: leftPadding + rightPadding + modelWidth + (indicator ? indicator.width : 10)
                 enabled: !playButton.checked
                 model: missionsModel
                 textRole: "name"
 
-                // Add background to the ComboBox
+                // Add a background to the ComboBox
                 Rectangle {
                     anchors.fill: parent
                     radius: 10
+                    // Make the rectangle visible if a dropdown indicator exists
+                    // An indicator only exists if a theme is set
+                    visible: parent.indicator
+                    border.width: 1
                 }
 
                 onModelChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -88,14 +88,18 @@ Rectangle {
                 margins: 10
             }
 
-            // Add background to the ComboBox
+            // Add a background to the ComboBox
             Rectangle {
                 anchors.fill: parent
                 radius: 10
+                // Make the rectangle visible if a dropdown indicator exists
+                // An indicator only exists if a theme is set
+                visible: parent.indicator
+                border.width: 1
             }
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding + indicator.width
+            width: modelWidth + leftPadding + rightPadding + (indicator ? indicator.width : 10)
             model: ["TOTAL POPULATION", "POPULATION DENSITY"]
 
             onCurrentTextChanged: {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -95,7 +95,7 @@ Rectangle {
             }
 
             property int modelWidth: 0
-            width: modelWidth + leftPadding + rightPadding
+            width: modelWidth + leftPadding + rightPadding + indicator.width
             model: ["TOTAL POPULATION", "POPULATION DENSITY"]
 
             onCurrentTextChanged: {
@@ -108,7 +108,7 @@ Rectangle {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width + 20);
+                    modelWidth = Math.max(modelWidth, metrics.width);
                 }
             }
             TextMetrics {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/FeatureLayerExtrusion.qml
@@ -87,6 +87,13 @@ Rectangle {
                 left: parent.left
                 margins: 10
             }
+
+            // Add background to the ComboBox
+            Rectangle {
+                anchors.fill: parent
+                radius: 10
+            }
+
             property int modelWidth: 0
             width: modelWidth + leftPadding + rightPadding
             model: ["TOTAL POPULATION", "POPULATION DENSITY"]
@@ -101,7 +108,7 @@ Rectangle {
             Component.onCompleted : {
                 for (let i = 0; i < model.length; ++i) {
                     metrics.text = model[i];
-                    modelWidth = Math.max(modelWidth, metrics.width);
+                    modelWidth = Math.max(modelWidth, metrics.width + 20);
                 }
             }
             TextMetrics {


### PR DESCRIPTION
# Description

Qt 6.5 introduces changes to the Material theme that our Sample Viewers use. Some of these changes break our UIs a bit, so this PR updates affected UIs to work with this new theme. Most commonly affected were the ComboBox components. I added a background rectangle where necessary and also added some width padding to the boxes to account for the dropdown arrows. I'm opening this PR after testing on macOS but will test on all platforms.

## Type of change

- [x] Bug fix
- [x] Sample viewer enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS