### PR TITLE
Don't initialize sample viewer with a sample

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SampleListView.qml
@@ -68,7 +68,7 @@ Page {
         ListView {
             anchors.fill: parent
             clip: true
-            model: SampleManager.currentCategory.samples
+            model: SampleManager.currentCategory ? SampleManager.currentCategory.samples : []
             spacing: 10
             delegate: ItemDelegate {
                 id: itemDelegate

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
@@ -84,7 +84,7 @@ Rectangle {
             topMargin: 10
         }
         width: 200
-        model: SampleManager.currentSample.codeFiles
+        model: SampleManager.currentSample ? SampleManager.currentSample.codeFiles : []
         textRole: "name"
 
         delegate: ItemDelegate {
@@ -106,7 +106,7 @@ Rectangle {
             horizontalAlignment: Text.AlignHCenter
         }
 
-        visible: SampleManager.currentSample.codeFiles.size > 1
+        visible: SampleManager.currentSample ? SampleManager.currentSample.codeFiles.size > 1 : false
         onCurrentTextChanged: SampleManager.setSourceCodeIndex(currentIndex)
 
         onModelChanged: {

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -95,9 +95,9 @@ ApplicationWindow {
                     }
                     MenuItem {
                         width: parent.width
-                        height: 48
+                        height: SampleManager.currentSample ? 48 : 0
                         text: qsTr("Live Sample")
-                        enabled: SampleManager.currentSample
+                        visible: SampleManager.currentSample
                         onTriggered: {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
@@ -110,9 +110,9 @@ ApplicationWindow {
                     }
                     MenuItem {
                         width: parent.width
-                        height: 48
+                        height: SampleManager.currentSample ? 48 : 0
                         text: qsTr("Source Code")
-                        enabled: SampleManager.currentSample
+                        visible: SampleManager.currentSample
                         onTriggered: {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
@@ -123,9 +123,9 @@ ApplicationWindow {
                     }
                     MenuItem {
                         width: parent.width
-                        height: 48
+                        height: SampleManager.currentSample ? 48 : 0
                         text: qsTr("Description")
-                        enabled: SampleManager.currentSample
+                        visible: SampleManager.currentSample
                         onTriggered: {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
@@ -142,7 +142,7 @@ ApplicationWindow {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
                             proxySetupView.visible = false;
-                            if (SampleManager.currentMode != SampleManager.DownloadDataView || !SampleManager.downloadInProgress)
+                            if (SampleManager.currentMode !== SampleManager.DownloadDataView || !SampleManager.downloadInProgress)
                                 SampleManager.currentMode = SampleManager.ManageOfflineDataView
                         }
                     }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -97,6 +97,7 @@ ApplicationWindow {
                         width: parent.width
                         height: 48
                         text: qsTr("Live Sample")
+                        enabled: SampleManager.currentSample
                         onTriggered: {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
@@ -111,6 +112,7 @@ ApplicationWindow {
                         width: parent.width
                         height: 48
                         text: qsTr("Source Code")
+                        enabled: SampleManager.currentSample
                         onTriggered: {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
@@ -123,6 +125,7 @@ ApplicationWindow {
                         width: parent.width
                         height: 48
                         text: qsTr("Description")
+                        enabled: SampleManager.currentSample
                         onTriggered: {
                             aboutView.visible = false;
                             gAnalyticsView.visible = false;
@@ -304,9 +307,6 @@ ApplicationWindow {
                 qmlLoaderAuthView.setSource("qrc:/qml/CppAuthenticationView.qml");
             }
 
-            // set the initial sample to the "Change Basemap" sample
-            SampleManager.currentCategory = SampleManager.categories.get(0);
-            SampleManager.currentSample = SampleManager.currentCategory.samples.get(2);
             SampleManager.currentMode = SampleManager.HomepageView;
         }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/main.qml
@@ -95,7 +95,7 @@ ApplicationWindow {
                     }
                     MenuItem {
                         width: parent.width
-                        height: SampleManager.currentSample ? 48 : 0
+                        height: visible ? 48 : 0
                         text: qsTr("Live Sample")
                         visible: SampleManager.currentSample
                         onTriggered: {
@@ -110,7 +110,7 @@ ApplicationWindow {
                     }
                     MenuItem {
                         width: parent.width
-                        height: SampleManager.currentSample ? 48 : 0
+                        height: visible ? 48 : 0
                         text: qsTr("Source Code")
                         visible: SampleManager.currentSample
                         onTriggered: {
@@ -123,7 +123,7 @@ ApplicationWindow {
                     }
                     MenuItem {
                         width: parent.width
-                        height: SampleManager.currentSample ? 48 : 0
+                        height: visible ? 48 : 0
                         text: qsTr("Description")
                         visible: SampleManager.currentSample
                         onTriggered: {


### PR DESCRIPTION
# Description

This PR makes it so the sample viewer no longer starts with an initial sample loaded in the background. Therefore the live sample view, description view, and source code view, all start disabled as well.

## Type of change

- [x] Sample viewer enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS