### PR TITLE
Define error variable

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.qml
@@ -29,7 +29,7 @@ CreateAndSaveMapSample {
         stackView.push(options);
     }
 
-    onSaveMapCompleted: (success, itemId) => {
+    onSaveMapCompleted: (success, itemId, error) => {
         if (stackView.currentItem === completionRect)
             return;
 


### PR DESCRIPTION
# Description

Really small bug fix. The sample wouldn't display any error text upon error because that variable wasn't defined. Tested and verified that this fixes it. This only affected C++, not QML.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] macOS