### PR TITLE
Force sample viewer light mode

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/resources/qtquickcontrols2.conf
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/resources/qtquickcontrols2.conf
@@ -4,4 +4,4 @@ Style=Material
 [Material]
 Primary=#7938b6
 Accent=#9453ce
-Theme=System
+Theme=Light


### PR DESCRIPTION
# Description

Sets the Sample Viewer Material 3 theme to use Light mode regardless of the system preset. Many of our samples don't display properly in dark mode so until we can update that, let's force light mode.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS