### PR TITLE
QSG_RHI_BACKEND env no longer honored at 6.5.1.

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
@@ -308,9 +308,7 @@ void registerCppSampleClasses();
 
 int main(int argc, char *argv[])
 {
-  // add support for feature toggles on mobile, which is disabled by default
-  qputenv("QT_ENABLE_FEATURE_TOGGLE_MOBILE", "true");
-  qputenv("QSG_RHI_BACKEND", "opengl");
+  QQuickWindow::setGraphicsApi(QSGRendererInterface::GraphicsApi::OpenGL);
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();


### PR DESCRIPTION
# Description

For unknown reasons the `QSG_RHI_BACKEND` environment variable no longer works to enforce OpenGL. We need to keep using OpenGL for now until we sort out shader deployment logistics in the builds.

I realize that hundreds of individual samples use `qputenv("QSG_RHI_BACKEND", "opengl");`, but my hope is that is short-lived anyway and we can remove this and all those as well within the next sprint or so. We can revisit all of those if we need to.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
