### PR TITLE
on iOS with Qt 6.5.1, a TextEdit with focus prevents buttons from getting pressed

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/CreateMobileGeodatabase.qml
@@ -205,6 +205,7 @@ Item {
                 id: gdbPathText
                 width: parent.width
                 readOnly: true
+                activeFocusOnPress: false
                 selectByMouse: true
                 text: model.gdbFilePath
                 wrapMode: Text.WrapAnywhere

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DescriptionView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/DescriptionView.qml
@@ -36,7 +36,7 @@ Rectangle {
             width: descriptionView.width - (40)
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             readOnly: true
-            focus: true
+            activeFocusOnPress: false
             textFormat: Text.MarkdownText
             text: descriptionText
             onLinkActivated: Qt.openUrlExternally(link)

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
@@ -34,7 +34,7 @@ Rectangle {
             id: textEdit
             anchors.margins: 15
             readOnly: true
-            focus: true
+            activeFocusOnPress: false
             textFormat: Text.PlainText
             selectByMouse: os === "ios" || os === "android" ? false : true
             Component.onCompleted: {


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

After building everything with Qt 6.5.1 on iOS, it was discovered that buttons no longer worked, unless you dragged a little between the touch-down and the touch-up. The underlying culprit is any TextEdit with focus. Once a TextEdit gets focus, it's game over. The fix here is to prevent TextEdit's from getting focus. This doesn't negatively impact any functionality with our TextEdit's -- there's no need for them to get focus.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
