### PR TITLE
Use unit factory in geodesic buffer and fix enum typo

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/Buffer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/Buffer.qml
@@ -120,7 +120,8 @@ Rectangle {
         graphicsOverlayPlanar.graphics.append(resultGraphic);
 
         // Create a geodesic buffer graphic using the same location and distance.
-        const bufferGeodesic = GeometryEngine.bufferGeodetic(point, bufferInMeters, Enums.LinearUnitIdMeters, NaN, Enums.geodesicCurveTypeGeodesic);
+        const bufferGeodesic = GeometryEngine.bufferGeodetic(point, bufferInMeters, Factory.Unit.createFromWkid(9001) /*meters*/,
+                                                             NaN, Enums.GeodeticCurveTypeGeodesic);
 
         // Add the result planar buffer as a graphic
         const resultGraphicGeodesic = ArcGISRuntimeEnvironment.createObject("Graphic", {


### PR DESCRIPTION
# Description

The Geodetic buffer was not displaying because we were passing in an enum for the linear units rather than the QML Object that the function expects. Is this an expected change?

Previous error message:
```
"Could not convert argument 2 at"
	 "bufferPoint@qrc:/Samples/Geometry/Buffer/Buffer.qml:123"
	 "@qrc:/Samples/Geometry/Buffer/Buffer.qml:47"
qrc:/Samples/Geometry/Buffer/Buffer.qml:123: TypeError: Passing incompatible arguments to C++ functions from JavaScript is not allowed.
```

## Type of change

- [x] Bug fix

**Platforms tested on**:


- [x] macOS