### PR TITLE
Tanneryould/xml parser samples

### DIFF
--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.pro
@@ -24,7 +24,8 @@ include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++17
 
-SOURCES += main.cpp
+SOURCES += main.cpp \
+    XmlParser.cpp
 
 RESOURCES += GODictionaryRenderer.qrc
 
@@ -34,3 +35,6 @@ ios {
 
 # Default rules for deployment.
 include(deployment.pri)
+
+HEADERS += \
+    XmlParser.h

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -31,12 +31,6 @@ Rectangle {
     }
     property bool graphicsLoaded: false
 
-    Map {
-        id: map
-        Basemap {
-            initStyle: Enums.BasemapStyleArcGISTopographic
-        }
-    }
 
     // Create MapView that a GraphicsOverlay
     // for the military symbols.
@@ -44,16 +38,19 @@ Rectangle {
         id: mapView
         anchors.fill: parent
 
+        Map {
+            id: map
+            Basemap {
+                initStyle: Enums.BasemapStyleArcGISTopographic
+            }
+        }
+
         Component.onCompleted: {
             // Set the focus on MapView to initially enable keyboard navigation
             forceActiveFocus();
 
             // Read the XML file and create a graphic from each entry
-            const parsedXml = xmlParser.parseXmlFile(dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
-            parsedXml.forEach(element => {createGraphicFromElement(element)});
-
-            graphicsLoaded = true;
-            mapView.map = map;
+            xmlParser.parseXmlFileAsync(dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
         }
 
         // The GraphicsOverlay does not have a valid extent until it has been added
@@ -100,6 +97,11 @@ Rectangle {
 
     XmlParser {
         id: xmlParser
+
+        onXmlParseComplete: (parsedXml) => {
+                                parsedXml.forEach(element => {createGraphicFromElement(element)});
+                                graphicsLoaded = true;
+                            }
     }
 
     function createGraphicFromElement(element) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qml
@@ -16,9 +16,9 @@
 
 import QtQuick
 import QtQuick.Controls
-import QtQuick.XmlListModel
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
+import Esri.samples
 
 Rectangle {
     width: 800
@@ -47,6 +47,13 @@ Rectangle {
         Component.onCompleted: {
             // Set the focus on MapView to initially enable keyboard navigation
             forceActiveFocus();
+
+            // Read the XML file and create a graphic from each entry
+            const parsedXml = xmlParser.parseXmlFile(dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
+            parsedXml.forEach(element => {createGraphicFromElement(element)});
+
+            graphicsLoaded = true;
+            mapView.map = map;
         }
 
         // The GraphicsOverlay does not have a valid extent until it has been added
@@ -91,69 +98,50 @@ Rectangle {
         visible: !graphicsLoaded
     }
 
-    // Use XmlListModel to parse the XML messages file.
-    XmlListModel {
+    XmlParser {
         id: xmlParser
-        source: dataPath + "/xml/arcade_style/Mil2525DMessages.xml"
-        query: "/messages/message"
+    }
 
-        // These are the fields we need for MIL-STD-2525D symbology.
-        XmlRole { name: "_control_points"; query: "_control_points/string()" }
-        XmlRole { name: "_wkid"; query: "_wkid/number()" }
-        XmlRole { name: "identity"; query: "identity/number()" }
-        XmlRole { name: "symbolset"; query: "symbolset/number()" }
-        XmlRole { name: "symbolentity"; query: "symbolentity/number()" }
-        XmlRole { name: "echelon"; query: "echelon/number()" }
-        XmlRole { name: "specialentitysubtype"; query: "specialentitysubtype/number()" }
-        XmlRole { name: "indicator"; query: "indicator/number()" }
-        XmlRole { name: "modifier2"; query: "modifier2/number()" }
-        XmlRole { name: "uniquedesignation"; query: "uniquedesignation/string()" }
-        XmlRole { name: "additionalinformation"; query: "additionalinformation/string()" }
+    function createGraphicFromElement(element) {
+        let wkid = element._wkid;
+        if (!wkid) {
+            // If _wkid was absent, use WGS 1984 (4326) by default.
+            wkid = 4326;
+        }
+        const pointStrings = element._control_points.split(";");
+        const sr = ArcGISRuntimeEnvironment.createObject("SpatialReference", { wkid: wkid });
+        let geom;
+        if (pointStrings.length === 1) {
+            // It's a point
+            const pointBuilder = ArcGISRuntimeEnvironment.createObject("PointBuilder");
+            pointBuilder.spatialReference = sr;
+            const coords = pointStrings[0].split(",");
+            pointBuilder.setXY(coords[0], coords[1]);
+            geom = pointBuilder.geometry;
+        } else {
+            const builder = ArcGISRuntimeEnvironment.createObject("MultipointBuilder");
+            builder.spatialReference = sr;
 
-        onStatusChanged: {
-            if (status === XmlListModel.Ready) {
-                for (let i = 0; i < count; i++) {
-                    const element = get(i);
-                    let wkid = element._wkid;
-                    if (!wkid) {
-                        // If _wkid was absent, use WGS 1984 (4326) by default.
-                        wkid = 4326;
-                    }
-                    const pointStrings = element._control_points.split(";");
-                    const sr = ArcGISRuntimeEnvironment.createObject("SpatialReference", { wkid: wkid });
-                    let geom;
-                    if (pointStrings.length === 1) {
-                        // It's a point
-                        const pointBuilder = ArcGISRuntimeEnvironment.createObject("PointBuilder");
-                        pointBuilder.spatialReference = sr;
-                        const coords = pointStrings[0].split(",");
-                        pointBuilder.setXY(coords[0], coords[1]);
-                        geom = pointBuilder.geometry;
-                    } else {
-                        const builder = ArcGISRuntimeEnvironment.createObject("MultipointBuilder");
-                        builder.spatialReference = sr;
-
-                        for (let ptIndex = 0; ptIndex < pointStrings.length; ptIndex++) {
-                            const coords = pointStrings[ptIndex].split(",");
-                            builder.points.addPointXY(coords[0], coords[1]);
-                        }
-                        geom = builder.geometry;
-                    }
-                    if (geom) {
-                        // Get rid of _control_points and _wkid. They are not needed in the graphic's
-                        // attributes.
-                        element._control_points = undefined;
-                        element._wkid = undefined;
-
-                        const graphic = ArcGISRuntimeEnvironment.createObject("Graphic", { geometry: geom });
-                        graphic.attributes.attributesJson = element;
-                        graphicsOverlay.graphics.append(graphic);
-                    }
-                }
-
-                graphicsLoaded = true;
-                mapView.map = map;
+            for (let ptIndex = 0; ptIndex < pointStrings.length; ptIndex++) {
+                const coords = pointStrings[ptIndex].split(",");
+                builder.points.addPointXY(coords[0], coords[1]);
             }
+            geom = builder.geometry;
+        }
+        if (geom) {
+            const graphic = ArcGISRuntimeEnvironment.createObject("Graphic", { geometry: geom });
+            graphic.attributes.attributesJson = {
+                "identity": element.identity,
+                "symbolset": element.symbolset,
+                "symbolentity": element.symbolentity,
+                "echelon": element.echelon,
+                "specialentitysubtype": element.specialentitysubtype,
+                "indicator": element.indicator,
+                "modifier2": element.modifier2,
+                "uniquedesignation": element.uniquedesignation,
+                "additionalinformation": element.additionalinformation
+            };
+            graphicsOverlay.graphics.append(graphic);
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qrc
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qrc
@@ -4,5 +4,7 @@
         <file>GODictionaryRenderer.qml</file>
         <file>screenshot.png</file>
         <file>README.md</file>
+        <file>XmlParser.cpp</file>
+        <file>XmlParser.h</file>
     </qresource>
 </RCC>

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/README.metadata.json
@@ -35,7 +35,9 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "GODictionaryRenderer.qml"
+        "GODictionaryRenderer.qml",
+        "XmlParser.cpp",
+        "XmlParser.h"
     ],
     "title": "Graphics overlay (dictionary renderer)"
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.cpp
@@ -1,3 +1,18 @@
+// [Legal]
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
 #include "XmlParser.h"
 
 #include <QFile>
@@ -5,13 +20,19 @@
 #include <QVariantList>
 #include <QXmlStreamReader>
 #include <QUrl>
+#include <QtConcurrent/QtConcurrent>
 
 XmlParser::XmlParser(QObject *parent)
   : QObject{parent}
 {
 }
 
-QVariantList XmlParser::parseXmlFile(QString filePath)
+void XmlParser::parseXmlFileAsync(const QString& filePath)
+{
+  m_synchronizer.addFuture(QtConcurrent::run(&XmlParser::parseXmlFileInternal, this, filePath));
+}
+
+void XmlParser::parseXmlFileInternal(const QString& filePath)
 {
   QXmlStreamReader xmlParser;
   QVariantList parsedJsonList;
@@ -28,7 +49,7 @@ QVariantList XmlParser::parseXmlFile(QString filePath)
   if (!QFile::exists(pathToLocalFile))
   {
     qDebug() << xmlFile.fileName() << "does not exist";
-    return parsedJsonList;
+    emit xmlParseComplete(parsedJsonList);
   }
 
   // Open the file for reading
@@ -88,5 +109,5 @@ QVariantList XmlParser::parseXmlFile(QString filePath)
       }
     }
   }
-  return parsedJsonList;
+  emit xmlParseComplete(parsedJsonList);
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.cpp
@@ -1,0 +1,92 @@
+#include "XmlParser.h"
+
+#include <QFile>
+#include <QVariantMap>
+#include <QVariantList>
+#include <QXmlStreamReader>
+#include <QUrl>
+
+XmlParser::XmlParser(QObject *parent)
+  : QObject{parent}
+{
+}
+
+QVariantList XmlParser::parseXmlFile(QString filePath)
+{
+  QXmlStreamReader xmlParser;
+  QVariantList parsedJsonList;
+
+  bool readingMessage = false;
+  QVariantMap elementValues;
+  QString currentElementName;
+
+  QUrl fileUrl(filePath);
+  const QString pathToLocalFile = fileUrl.toLocalFile();
+
+  QFile xmlFile(pathToLocalFile);
+
+  if (!QFile::exists(pathToLocalFile))
+  {
+    qDebug() << xmlFile.fileName() << "does not exist";
+    return parsedJsonList;
+  }
+
+  // Open the file for reading
+  if (xmlFile.isOpen())
+  {
+    xmlFile.reset();
+  }
+  else
+  {
+    xmlFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  }
+  xmlParser.setDevice(&xmlFile);
+
+  while (!xmlParser.atEnd())
+  {
+    xmlParser.readNext();
+
+    // Is this the start or end of a message element?
+    if (xmlParser.name() == QString("message"))
+    {
+      if (!readingMessage)
+      {
+        // This is the start of a message element.
+        elementValues.clear();
+      }
+      else
+      {
+        // This is the end of a message element. Here we have a complete message that defines
+        // a military feature to display on the map. Create a graphic from its attributes.
+        parsedJsonList.append(elementValues);
+      }
+      // Either we just started reading a message, or we just finished reading a message.
+      readingMessage = !readingMessage;
+    }
+    // Are we already inside a message element?
+    else if (readingMessage)
+    {
+      // Is this the start of an element inside a message?
+      if (xmlParser.isStartElement())
+      {
+        // Remember which element we're reading
+        currentElementName = xmlParser.name().toString();
+      }
+      // Is this text?
+      else if (xmlParser.isCharacters())
+      {
+        // Is this text inside an element?
+        if (!currentElementName.isEmpty())
+        {
+          // Get the text and store it as the current element's value
+          const QStringView trimmedText = xmlParser.text().trimmed();
+          if (!trimmedText.isEmpty())
+          {
+            elementValues[currentElementName] = trimmedText.toString();
+          }
+        }
+      }
+    }
+  }
+  return parsedJsonList;
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.h
@@ -1,15 +1,38 @@
+// [Legal]
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
 #ifndef XMLPARSER_H
 #define XMLPARSER_H
 
 #include <QObject>
+#include <QVariantList>
+#include <QFutureSynchronizer>
 
 class XmlParser : public QObject
 {
   Q_OBJECT
 public:
   explicit XmlParser(QObject *parent = nullptr);
-  Q_INVOKABLE QVariantList parseXmlFile(QString filePath);
+  Q_INVOKABLE void parseXmlFileAsync(const QString& filePath);
 
+signals:
+  void xmlParseComplete(QVariantList parsedXmlElements);
+
+private:
+  void parseXmlFileInternal(const QString& filePath);
+  QFutureSynchronizer<void> m_synchronizer;
 };
 
 #endif // XMLPARSER_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/XmlParser.h
@@ -1,0 +1,15 @@
+#ifndef XMLPARSER_H
+#define XMLPARSER_H
+
+#include <QObject>
+
+class XmlParser : public QObject
+{
+  Q_OBJECT
+public:
+  explicit XmlParser(QObject *parent = nullptr);
+  Q_INVOKABLE QVariantList parseXmlFile(QString filePath);
+
+};
+
+#endif // XMLPARSER_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -16,6 +16,8 @@
 #include <QDir>
 #include <QQmlEngine>
 
+#include "XmlParser.h"
+
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
 
@@ -48,6 +50,9 @@ int main(int argc, char *argv[])
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);
+
+  // Register the C++ XmlParser class
+  qmlRegisterType<XmlParser>("Esri.samples", 1, 0, "XmlParser");
 
   // Add the import Path
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.pro
@@ -24,7 +24,8 @@ include($$PWD/arcgisruntime.pri)
 
 CONFIG += c++17
 
-SOURCES += main.cpp
+SOURCES += main.cpp \
+    XmlParser.cpp
 
 RESOURCES += GODictionaryRenderer_3D.qrc
 
@@ -34,3 +35,5 @@ ios {
 
 # Default rules for deployment.
 include(deployment.pri)
+
+HEADERS += XmlParser.h

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -16,9 +16,9 @@
 
 import QtQuick
 import QtQuick.Controls
-import QtQuick.XmlListModel
 import Esri.ArcGISRuntime
 import Esri.ArcGISExtras
+import Esri.samples
 
 Rectangle {
     width: 800
@@ -53,6 +53,32 @@ Rectangle {
                     url: "https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
                 }
             }
+
+            onLoadStatusChanged: {
+                if (loadStatus !== Enums.LoadStatusLoaded)
+                    return;
+
+                // Read the XML file and create a graphic from each entry
+                const parsedXml = xmlParser.parseXmlFile(dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
+                parsedXml.forEach(element => {createGraphicFromElement(element)});
+
+                progressBar_loading.visible = false;
+
+                // Zoom to graphics
+                /*
+                 * Create a camera directly above the center of the features, and then rotate that
+                 * camera around the center to tip it.
+                 */
+                let camera = ArcGISRuntimeEnvironment.createObject("Camera", {
+                                                                       location: graphicsOverlay.extent.center,
+                                                                       heading: 0,
+                                                                       pitch: 0,
+                                                                       roll: 0,
+                                                                       distance: 15000
+                                                                   });
+                camera = camera.rotateAround(graphicsOverlay.extent.center, 0, 70, 0);
+                sceneView.setViewpointCameraAndWait(camera);
+            }
         }
         GraphicsOverlay {
             id: graphicsOverlay
@@ -74,91 +100,50 @@ Rectangle {
         indeterminate: true
     }
 
-    // Use XmlListModel to parse the XML messages file.
-    XmlListModel {
+    XmlParser {
         id: xmlParser
-        source: dataPath + "/xml/arcade_style/Mil2525DMessages.xml"
-        query: "/messages/message"
+    }
 
-        // These are the fields we need for MIL-STD-2525D symbology.
-        XmlRole { name: "_control_points"; query: "_control_points/string()" }
-        XmlRole { name: "_wkid"; query: "_wkid/number()" }
-        XmlRole { name: "identity"; query: "identity/number()" }
-        XmlRole { name: "symbolset"; query: "symbolset/number()" }
-        XmlRole { name: "symbolentity"; query: "symbolentity/number()" }
-        XmlRole { name: "echelon"; query: "echelon/number()" }
-        XmlRole { name: "specialentitysubtype"; query: "specialentitysubtype/number()" }
-        XmlRole { name: "indicator"; query: "indicator/number()" }
-        XmlRole { name: "modifier2"; query: "modifier2/number()" }
-        XmlRole { name: "uniquedesignation"; query: "uniquedesignation/string()" }
-        XmlRole { name: "additionalinformation"; query: "additionalinformation/string()" }
+    function createGraphicFromElement(element) {
+        let wkid = element._wkid;
+        if (!wkid) {
+            // If _wkid was absent, use WGS 1984 (4326) by default.
+            wkid = 4326;
+        }
+        const pointStrings = element._control_points.split(";");
+        const sr = ArcGISRuntimeEnvironment.createObject("SpatialReference", { wkid: wkid });
+        let geom;
+        if (pointStrings.length === 1) {
+            // It's a point
+            const pointBuilder = ArcGISRuntimeEnvironment.createObject("PointBuilder");
+            pointBuilder.spatialReference = sr;
+            const coords = pointStrings[0].split(",");
+            pointBuilder.setXY(coords[0], coords[1]);
+            geom = pointBuilder.geometry;
+        } else {
+            const builder = ArcGISRuntimeEnvironment.createObject("MultipointBuilder");
+            builder.spatialReference = sr;
 
-        onStatusChanged: {
-            if (status === XmlListModel.Ready) {
-                let bbox = null;
-                for (let i = 0; i < count; i++) {
-                    const element = get(i);
-                    let wkid = element._wkid;
-                    if (!wkid) {
-                        // If _wkid was absent, use WGS 1984 (4326) by default.
-                        wkid = 4326;
-                    }
-                    const pointStrings = element._control_points.split(";");
-                    const sr = ArcGISRuntimeEnvironment.createObject("SpatialReference", { wkid: wkid });
-
-                    let geom = null;
-                    if (pointStrings.length === 1) {
-                        // It's a point
-                        const pointBuilder = ArcGISRuntimeEnvironment.createObject("PointBuilder", {
-                                                                                       spatialReference: sr
-                                                                                   });
-                        const coords = pointStrings[0].split(",");
-                        pointBuilder.setXY(coords[0], coords[1]);
-                        geom = pointBuilder.geometry;
-                    }
-
-                    if (geom) {
-                        /**
-                         * Get rid of _control_points and _wkid. They are not needed in the graphic's
-                         * attributes.
-                         */
-                        element._control_points = undefined;
-                        element._wkid = undefined;
-
-                        const graphic = ArcGISRuntimeEnvironment.createObject("Graphic", {
-                                                                                  geometry: geom
-                                                                              });
-                        graphic.attributes.attributesJson = element;
-                        graphicsOverlay.graphics.append(graphic);
-
-                        if (bbox) {
-                            bbox = GeometryEngine.unionOf(bbox, geom);
-                        } else {
-                            bbox = geom;
-                        }
-                    }
-                }
-
-                // Zoom to graphics
-                if (bbox) {
-                    bbox = GeometryEngine.project(bbox.extent, scene.spatialReference);
-
-                    /**
-                     * Create a camera directly above the center of the features, and then rotate that
-                     * camera around the center to tip it.
-                     */
-                    let camera = ArcGISRuntimeEnvironment.createObject("Camera", {
-                                                                           location: bbox.extent.center,
-                                                                           heading: 0,
-                                                                           pitch: 0,
-                                                                           roll: 0,
-                                                                           distance: 15000
-                                                                       });
-                    camera = camera.rotateAround(bbox.extent.center, 0, 70, 0);
-                    sceneView.setViewpointCameraAndWait(camera);
-                }
-                progressBar_loading.visible = false;
+            for (let ptIndex = 0; ptIndex < pointStrings.length; ptIndex++) {
+                const coords = pointStrings[ptIndex].split(",");
+                builder.points.addPointXY(coords[0], coords[1]);
             }
+            geom = builder.geometry;
+        }
+        if (geom) {
+            const graphic = ArcGISRuntimeEnvironment.createObject("Graphic", { geometry: geom });
+            graphic.attributes.attributesJson = {
+                "identity": element.identity,
+                "symbolset": element.symbolset,
+                "symbolentity": element.symbolentity,
+                "echelon": element.echelon,
+                "specialentitysubtype": element.specialentitysubtype,
+                "indicator": element.indicator,
+                "modifier2": element.modifier2,
+                "uniquedesignation": element.uniquedesignation,
+                "additionalinformation": element.additionalinformation
+            };
+            graphicsOverlay.graphics.append(graphic);
         }
     }
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -69,14 +69,15 @@ Rectangle {
                  * Create a camera directly above the center of the features, and then rotate that
                  * camera around the center to tip it.
                  */
+
+                const initialLocation = ArcGISRuntimeEnvironment.createObject("Point", {x: -2.0344707, y: 51.29712})
                 let camera = ArcGISRuntimeEnvironment.createObject("Camera", {
-                                                                       location: graphicsOverlay.extent.center,
+                                                                       location: initialLocation,
                                                                        heading: 0,
-                                                                       pitch: 0,
+                                                                       pitch: 70,
                                                                        roll: 0,
                                                                        distance: 15000
                                                                    });
-                camera = camera.rotateAround(graphicsOverlay.extent.center, 0, 70, 0);
                 sceneView.setViewpointCameraAndWait(camera);
             }
         }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qml
@@ -30,7 +30,7 @@ Rectangle {
                     System.writableLocationUrl(System.StandardPathsHomeLocation) + "/ArcGIS/Runtime/Data"
     }
 
-    /**
+    /*
      * Create SceneView that contains a Scene with the Imagery Basemap, as well as a GraphicsOverlay
      * for the military symbols.
      */
@@ -59,10 +59,7 @@ Rectangle {
                     return;
 
                 // Read the XML file and create a graphic from each entry
-                const parsedXml = xmlParser.parseXmlFile(dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
-                parsedXml.forEach(element => {createGraphicFromElement(element)});
-
-                progressBar_loading.visible = false;
+                const parsedXml = xmlParser.parseXmlFileAsync(dataPath + "/xml/arcade_style/Mil2525DMessages.xml");
 
                 // Zoom to graphics
                 /*
@@ -103,6 +100,11 @@ Rectangle {
 
     XmlParser {
         id: xmlParser
+
+        onXmlParseComplete: (parsedXml) => {
+                                parsedXml.forEach(element => {createGraphicFromElement(element)});
+                                progressBar_loading.visible = false;
+                            }
     }
 
     function createGraphicFromElement(element) {

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qrc
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qrc
@@ -4,5 +4,7 @@
         <file>GODictionaryRenderer_3D.qml</file>
         <file>screenshot.png</file>
         <file>README.md</file>
+        <file>XmlParser.cpp</file>
+        <file>XmlParser.h</file>
     </qresource>
 </RCC>

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/README.metadata.json
@@ -35,7 +35,10 @@
         "GraphicsOverlay"
     ],
     "snippets": [
-        "GODictionaryRenderer_3D.qml"
+        "GODictionaryRenderer_3D.qml",
+        "XmlParser.cpp",
+        "XmlParser.h"
+
     ],
     "title": "Graphics overlay (dictionary renderer) 3D"
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.cpp
@@ -1,3 +1,18 @@
+// [Legal]
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
 #include "XmlParser.h"
 
 #include <QFile>
@@ -5,13 +20,19 @@
 #include <QVariantList>
 #include <QXmlStreamReader>
 #include <QUrl>
+#include <QtConcurrent/QtConcurrent>
 
 XmlParser::XmlParser(QObject *parent)
   : QObject{parent}
 {
 }
 
-QVariantList XmlParser::parseXmlFile(QString filePath)
+void XmlParser::parseXmlFileAsync(const QString& filePath)
+{
+  m_synchronizer.addFuture(QtConcurrent::run(&XmlParser::parseXmlFileInternal, this, filePath));
+}
+
+void XmlParser::parseXmlFileInternal(const QString& filePath)
 {
   QXmlStreamReader xmlParser;
   QVariantList parsedJsonList;
@@ -28,7 +49,7 @@ QVariantList XmlParser::parseXmlFile(QString filePath)
   if (!QFile::exists(pathToLocalFile))
   {
     qDebug() << xmlFile.fileName() << "does not exist";
-    return parsedJsonList;
+    emit xmlParseComplete(parsedJsonList);
   }
 
   // Open the file for reading
@@ -88,5 +109,5 @@ QVariantList XmlParser::parseXmlFile(QString filePath)
       }
     }
   }
-  return parsedJsonList;
+  emit xmlParseComplete(parsedJsonList);
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.cpp
@@ -1,0 +1,92 @@
+#include "XmlParser.h"
+
+#include <QFile>
+#include <QVariantMap>
+#include <QVariantList>
+#include <QXmlStreamReader>
+#include <QUrl>
+
+XmlParser::XmlParser(QObject *parent)
+  : QObject{parent}
+{
+}
+
+QVariantList XmlParser::parseXmlFile(QString filePath)
+{
+  QXmlStreamReader xmlParser;
+  QVariantList parsedJsonList;
+
+  bool readingMessage = false;
+  QVariantMap elementValues;
+  QString currentElementName;
+
+  QUrl fileUrl(filePath);
+  const QString pathToLocalFile = fileUrl.toLocalFile();
+
+  QFile xmlFile(pathToLocalFile);
+
+  if (!QFile::exists(pathToLocalFile))
+  {
+    qDebug() << xmlFile.fileName() << "does not exist";
+    return parsedJsonList;
+  }
+
+  // Open the file for reading
+  if (xmlFile.isOpen())
+  {
+    xmlFile.reset();
+  }
+  else
+  {
+    xmlFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  }
+  xmlParser.setDevice(&xmlFile);
+
+  while (!xmlParser.atEnd())
+  {
+    xmlParser.readNext();
+
+    // Is this the start or end of a message element?
+    if (xmlParser.name() == QString("message"))
+    {
+      if (!readingMessage)
+      {
+        // This is the start of a message element.
+        elementValues.clear();
+      }
+      else
+      {
+        // This is the end of a message element. Here we have a complete message that defines
+        // a military feature to display on the map. Create a graphic from its attributes.
+        parsedJsonList.append(elementValues);
+      }
+      // Either we just started reading a message, or we just finished reading a message.
+      readingMessage = !readingMessage;
+    }
+    // Are we already inside a message element?
+    else if (readingMessage)
+    {
+      // Is this the start of an element inside a message?
+      if (xmlParser.isStartElement())
+      {
+        // Remember which element we're reading
+        currentElementName = xmlParser.name().toString();
+      }
+      // Is this text?
+      else if (xmlParser.isCharacters())
+      {
+        // Is this text inside an element?
+        if (!currentElementName.isEmpty())
+        {
+          // Get the text and store it as the current element's value
+          const QStringView trimmedText = xmlParser.text().trimmed();
+          if (!trimmedText.isEmpty())
+          {
+            elementValues[currentElementName] = trimmedText.toString();
+          }
+        }
+      }
+    }
+  }
+  return parsedJsonList;
+}

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.h
@@ -1,15 +1,38 @@
+// [Legal]
+// Copyright 2023 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
 #ifndef XMLPARSER_H
 #define XMLPARSER_H
 
 #include <QObject>
+#include <QVariantList>
+#include <QFutureSynchronizer>
 
 class XmlParser : public QObject
 {
   Q_OBJECT
 public:
   explicit XmlParser(QObject *parent = nullptr);
-  Q_INVOKABLE QVariantList parseXmlFile(QString filePath);
+  Q_INVOKABLE void parseXmlFileAsync(const QString& filePath);
 
+signals:
+  void xmlParseComplete(QVariantList parsedXmlElements);
+
+private:
+  void parseXmlFileInternal(const QString& filePath);
+  QFutureSynchronizer<void> m_synchronizer;
 };
 
 #endif // XMLPARSER_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/XmlParser.h
@@ -1,0 +1,15 @@
+#ifndef XMLPARSER_H
+#define XMLPARSER_H
+
+#include <QObject>
+
+class XmlParser : public QObject
+{
+  Q_OBJECT
+public:
+  explicit XmlParser(QObject *parent = nullptr);
+  Q_INVOKABLE QVariantList parseXmlFile(QString filePath);
+
+};
+
+#endif // XMLPARSER_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -17,6 +17,8 @@
 #include <QQmlEngine>
 #include <QSurfaceFormat>
 
+#include "XmlParser.h"
+
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
 
@@ -57,6 +59,9 @@ int main(int argc, char *argv[])
   // Initialize application view
   QQuickView view;
   view.setResizeMode(QQuickView::SizeRootObjectToView);
+
+  // Register the C++ XmlParser class
+  qmlRegisterType<XmlParser>("Esri.samples", 1, 0, "XmlParser");
 
   // Add the import Path
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/samples.pri
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/samples.pri
@@ -11,13 +11,16 @@
 #  See the Sample code usage restrictions document for further information.
 #-------------------------------------------------
 HEADERS += \
-    "$$SAMPLEPATHQML/Routing/NavigateRoute/NavigateRouteSpeaker.h"
+    "$$SAMPLEPATHQML/Routing/NavigateRoute/NavigateRouteSpeaker.h" \
+    "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer/XmlParser.h"
 
 INCLUDEPATH += \
-    "$$SAMPLEPATHQML/Routing/NavigateRoute"
+    "$$SAMPLEPATHQML/Routing/NavigateRoute" \
+    "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer"
 
 SOURCES += \
-    "$$SAMPLEPATHQML/Routing/NavigateRoute/NavigateRouteSpeaker.cpp"
+    "$$SAMPLEPATHQML/Routing/NavigateRoute/NavigateRouteSpeaker.cpp" \
+    "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer/XmlParser.cpp"
 
 RESOURCES += \
     "$$SAMPLEPATHQML/Analysis/AnalyzeHotspots/AnalyzeHotspots.qrc" \
@@ -39,8 +42,8 @@ RESOURCES += \
     "$$SAMPLEPATHQML/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qrc" \
     "$$SAMPLEPATHQML/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qrc" \
     "$$SAMPLEPATHQML/DisplayInformation/DisplayGrid/DisplayGrid.qrc" \
-    # "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qrc" \ # Qt 6.2 does not support getting entries from an xml list
-    # "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qrc" \ # Qt 6.2 does not support getting entries from an xml list
+    "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qrc" \
+    "$$SAMPLEPATHQML/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qrc" \
     "$$SAMPLEPATHQML/DisplayInformation/GOSymbols/GOSymbols.qrc" \
     "$$SAMPLEPATHQML/DisplayInformation/IdentifyGraphics/IdentifyGraphics.qrc" \
     "$$SAMPLEPATHQML/DisplayInformation/Picture_Marker_Symbol/Picture_Marker_Symbol.qrc" \

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
@@ -293,9 +293,10 @@
 #include "RasterFunctionFile.h"
 #endif // SHOW_RASTER_FUNCTION_SAMPLE
 
-#else
+#else // QML_VIEWER
 #include "NavigateRouteSpeaker.h"
-#endif // CPP_VIEWER
+#include "XmlParser.h"
+#endif
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
@@ -632,8 +633,10 @@ void registerClasses()
   qmlRegisterType<SampleSearchFilterModel>("Esri.ArcGISRuntimeSamples", 1, 0, "SampleSearchFilterModel");
   qmlRegisterUncreatableType<SearchFilterCriteria>("Esri.ArcGISRuntimeSamples", 1, 0, "SearchFilterCriteria", "Abstract base class");
 
+
 #ifndef CPP_VIEWER
   qmlRegisterType<NavigateRouteSpeaker>("Esri.samples", 1, 0, "NavigateRouteSpeaker");
+  qmlRegisterType<XmlParser>("Esri.samples", 1, 0, "XmlParser");
 #endif
 
   // register the C++ Sample Classes if building for C++ API


### PR DESCRIPTION
# Description

Updates the GraphicsOverlayDictionaryRenderer QML samples that previously used a deprecated XmlListModel Qt Quick component to parse their xml data. This samples now makes use of a C++ helper class to parse the xml data and return it as a list of json objects to loop over and turn into graphics.

The helper class is used by two samples and I wasn't sure if I should reference the class from another sample or if I should just duplicate the class. I ended up opting for the latter.

## Type of change

- [x] Bug fix

**Platforms tested on**:

- [x] macOS