### PR TITLE
No need to enforce OpenGL anymore.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // There are some conflicts between the AR frameworks and Qt's rendering thread.
   // See Qt's documentation about non-threaded render loops for more information.
   // https://doc.qt.io/qt-5/qtquick-visualcanvas-scenegraph.html#non-threaded-render-loops-basic-and-windows

--- a/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // There are some conflicts between the AR frameworks and Qt's rendering thread.
   // See Qt's documentation about non-threaded render loops for more information.
   // https://doc.qt.io/qt-5/qtquick-visualcanvas-scenegraph.html#non-threaded-render-loops-basic-and-windows

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Analyze Hotspots - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Analyze Viewshed - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -29,9 +29,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Geotriggers - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/LineOfSightLocation/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQuery/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Statistical Query - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Statistical Query Group Sort - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedCamera/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/ViewshedLocation/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -33,9 +33,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -34,9 +34,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -34,9 +34,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -34,9 +34,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -35,9 +35,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Show Org Basemaps - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -35,9 +35,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddGraphicsWithRenderer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/BuildLegend/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Build Legend - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ControlAnnotationSublayerVisibility - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateSymbolStylesFromWebStyles - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CustomDictionaryStyle - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Display Grid - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GODictionary Renderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/GOSymbols/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GOSymbols - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Identify Graphics - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Picture Marker Symbol - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -30,9 +30,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("QueryFeaturesWithArcadeExpression - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ReadSymbolsFromMobileStyle - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowCallout/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Show Callout - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Show Labels on Layers - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ShowPopup - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Simple Marker Symbol - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Simple Renderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("SketchOnMap - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Symbolize Shapefile - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Unique Value Renderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddFeaturesFeatureService - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/ContingentValues/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ContingentValues - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -32,9 +32,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Delete Features Feature Service - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Edit and Sync Features - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/main.cpp
@@ -33,9 +33,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Edit Feature Attachments - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("EditFeaturesWithFeatureLinkedAnnotation - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("EditWithBranchVersioning - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -32,9 +32,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Update Attributes Feature Service - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Update Geometry Feature Service - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -29,9 +29,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ControlTimeExtentTimeSlider - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("CreateMobileGeodatabase - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerChangeRenderer- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerDictionaryRenderer- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerQuery/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerQuery- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("FeatureLayerSelection - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FilterByDefinitionExpressionOrDisplayFilter- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateGeodatabaseReplicaFromFeatureService- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ListRelatedFeatures/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListRelatedFeatures- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableCache/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTableCache- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTableManualCache- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTableNoCache- C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/Buffer/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("Buffer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ClipGeometry/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Clip geometry - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ConvexHull/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ConvexHull - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("CreateAndEditGeometries - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CreateGeometries/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("CreateGeometries - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/CutGeometry/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("CutGeometry - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/FormatCoordinates/main.cpp
@@ -32,9 +32,6 @@ using namespace Esri::ArcGISRuntime;
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FormatCoordinates - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/GeodesicOperations/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GeodesicOperations - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ListTransformations/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListTransformations - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/NearestVertex/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NearestVertex - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/ProjectGeometry/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ProjectGeometry - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialOperations/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SpatialOperations - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Geometry/SpatialRelationships/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SpatialRelationships - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddDynamicEntityLayer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/AddEncExchangeSet/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("AddEncExchangeSet - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ApplyMosaicRuleToRasters - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ApplyUniqueValuesWithAlternateSymbols - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -33,9 +33,6 @@ using namespace Esri::ArcGISRuntime;
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ArcGISMapImageLayerUrl - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -33,9 +33,6 @@ using namespace Esri::ArcGISRuntime;
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ArcGISTiledLayerUrl - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BlendRasterLayer/main.cpp
@@ -31,9 +31,6 @@ using namespace Esri::ArcGISRuntime;
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("BlendRasterLayer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("BrowseOGCAPIFeatureService - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/BrowseWfsLayers/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("BrowseWfsLayers - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeSublayerRenderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -32,9 +32,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeSublayerVisibility - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateAndSaveKmlFile - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayAnnotation - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayDimensions/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayDimensions - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayFeatureLayers - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKml/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayOgcApiFeatureCollection - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplaySubtypeFeatureLayer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/DisplayWfsLayer/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayWfsLayer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportTiles/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ExportTiles - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ExportVectorTiles - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FeatureCollectionLayerFromPortal - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureCollectionLayerQuery - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Feature_Collection_Layer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/GroupLayers/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Hillshade_Renderer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Hillshade_Renderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IdentifyKmlFeatures - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/IdentifyRasterCell/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IdentifyRasterCell - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ListKmlContents/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("LoadWfsXmlQuery - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ManageOperationalLayers/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ManageOperationalLayers - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/OSM_Layer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OSM_Layer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("QueryOGCAPICQLFilters - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterColormapRenderer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterColormapRenderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionFile/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterFunctionFile - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterFunctionService/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterFunctionService - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerFile/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerFile - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerGeoPackage - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterLayerService/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerService - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRenderingRule/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterRenderingRule - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterRgbRenderer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterRgbRenderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/RasterStretchRenderer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterStretchRenderer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/StyleWmsLayer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("StyleWmsLayer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/TileCacheLayer/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("TileCacheLayer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("VectorTiledLayerUrl - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WMTS_Layer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("WMTS_Layer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Web_Tiled_Layer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/WmsLayerUrl/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("WmsLayerUrl - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerFeatureLayer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerGeoprocessing - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerMapImageLayer - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerServices - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ApplyScheduledMapUpdates - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("BrowseBuildingFloors - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeBasemap/main.cpp
@@ -29,9 +29,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ChangeBasemap - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ChangeViewpoint/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeViewpoint - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/CreateAndSaveMap/main.cpp
@@ -34,9 +34,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayDeviceLocation - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayDeviceLocationWithNmeaDataSources - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayDrawingStatus - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayLayerViewDrawState - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayMap/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayMap - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -29,9 +29,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayOverviewMap - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DownloadPreplannedMap - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMap - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMapLocalBasemap - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMap_Overrides - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("HonorMobileMapPackageExpiration - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/IdentifyLayers/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("IdentifyLayers - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ManageBookmarks/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ManageBookmarks - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapLoaded/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("MapLoaded - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapReferenceScale/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("MapReferenceScale - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MapRotation/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("MapRotation - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MinMaxScale/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("MobileMap_SearchAndRoute - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMapUrl/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenMapUrl - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenMobileMap_MapPackage - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ReadGeoPackage/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapArea/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetInitialMapArea - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetInitialMapLocation/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetInitialMapLocation - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMapSpatialReference/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetMapSpatialReference - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/SetMaxExtent/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("SetMaxExtent - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ShowDeviceLocationUsingIndoorPositioning - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowLocationHistory/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ShowLocationHistory - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowMagnifier/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ShowMagnifier - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/TakeScreenshot/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("TakeScreenshot - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ClosestFacility/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ClosestFacility - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayRouteLayer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FindClosestFacilityToMultipleIncidentsService - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindRoute/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindRoute - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FindServiceAreasForMultipleFacilities - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("NavigateARouteWithRerouting - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NavigateRoute - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("OfflineRouting - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/RouteAroundBarriers/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("RouteAroundBarriers - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/ServiceArea/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceArea - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Animate3DSymbols/main.cpp
@@ -36,9 +36,6 @@ using namespace Esri::ArcGISRuntime;
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/BasicSceneView/main.cpp
@@ -29,9 +29,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -33,9 +33,6 @@ using namespace Esri::ArcGISRuntime;
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OpenScene/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SceneLayerSelection/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SurfacePlacement/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Symbols/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/TerrainExaggeration/main.cpp
@@ -30,9 +30,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindAddress/main.cpp
@@ -32,9 +32,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindAddress - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/FindPlace/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindPlace - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/main.cpp
@@ -31,9 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OfflineGeocode - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ReverseGeocodeOnline - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SearchDictionarySymbolStyle - C++");
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ConfigureSubnetworkTrace - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateLoadReport - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayContentOfUtilityNetworkContainer - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayUtilityAssociations - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("PerformValveIsolationTrace - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -27,9 +27,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("TraceUtilityNetwork - C++"));
 

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/BuildLegend/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GORenderers/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/DisplayInformation/GOSymbols/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeBasemap/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ChangeViewpoint/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QApplication application(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/DisplayMap/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/ManageBookmarks/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QApplication application(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapLoaded/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/MapRotation/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/OpenExistingMap/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapArea/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetInitialMapLocation/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Maps/SetMapSpatialReference/main.cpp
@@ -19,9 +19,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // Use of Esri location services, including basemaps and geocoding,
   // requires authentication using either an ArcGIS identity or an API Key.
   // 1. ArcGIS identity: An ArcGIS named user account that is a member of an

--- a/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples_Widgets/Scenes/BasicSceneView/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // There are some conflicts between the AR frameworks and Qt's rendering thread.
   // See Qt's documentation about non-threaded render loops for more information.
   // https://doc.qt.io/qt-5/qtquick-visualcanvas-scenegraph.html#non-threaded-render-loops-basic-and-windows

--- a/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // There are some conflicts between the AR frameworks and Qt's rendering thread.
   // See Qt's documentation about non-threaded render loops for more information.
   // https://doc.qt.io/qt-5/qtquick-visualcanvas-scenegraph.html#non-threaded-render-loops-basic-and-windows

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("AnalyzeHotspots - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("AnalyzeViewshed - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/Geotriggers/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Geotriggers - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/LineOfSightLocation/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQuery/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("StatisticalQuery - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("StatisticalQueryGroupSort - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedCamera/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Analysis/ViewshedLocation/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
     QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
     QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
 QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -29,9 +29,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("AddGraphicsWithRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/BuildLegend/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("BuildLegend - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ControlAnnotationSublayerVisibility - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateSymbolStylesFromWebStyles - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CustomDictionaryStyle - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayGrid - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GODictionaryRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/GOSymbols/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GOSymbols - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("IdentifyGraphics - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Picture_Marker_Symbol - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -24,9 +24,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("QueryFeaturesWithArcadeExpression - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ReadSymbolsFromMobileStyle - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowCallout/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ShowCallout - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ShowLabelsOnLayers - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/ShowPopup/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ShowPopup - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Simple_Marker_Symbol - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Simple_Renderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("SketchOnMap - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SymbolizeShapefile - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Unique_Value_Renderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("AddFeaturesFeatureService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/ContingentValues/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/ContingentValues/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ContingentValues - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DeleteFeaturesFeatureService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("EditAndSyncFeatures - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeatureAttachments/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
     QGuiApplication app(argc, argv);
     app.setApplicationName("EditFeatureAttachments - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("EditFeaturesWithFeatureLinkedAnnotation - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("EditKmlGroundOverlay - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -26,9 +26,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("UpdateAttributesFeatureService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("UpdateGeometryFeatureService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -24,9 +24,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ControlTimeExtentTimeSlider - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("CreateMobileGeodatabase - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_ChangeRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayer_ChangeRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_DictionaryRenderer/main.cpp
@@ -21,9 +21,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayer_DictionaryRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Query/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayer_Query - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FeatureLayer_Selection/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayer_Selection - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FilterByDefinitionExpressionOrDisplayFilter - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateGeodatabaseReplicaFromFeatureService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ListRelatedFeatures/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListRelatedFeatures - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_Cache/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTable_Cache - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_ManualCache/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTable_ManualCache - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Features/ServiceFeatureTable_NoCache/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTable_NoCache - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/Buffer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Buffer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ClipGeometry/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Clip geometry - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ConvexHull/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ConvexHull - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("CreateAndEditGeometries - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CreateGeometries/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("CreateGeometries - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/CutGeometry/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("CutGeometry - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/FormatCoordinates/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FormatCoordinates - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/GeodesicOperations/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GeodesicOperations - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ListTransformations/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListTransformations - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/NearestVertex/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NearestVertex - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/ProjectGeometry/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ProjectGeometry - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialOperations/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SpatialOperations - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Geometry/SpatialRelationships/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SpatialRelationships - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddDynamicEntityLayer - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/AddEncExchangeSet/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("AddEncExchangeSet - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ApplyMosaicRuleToRasters - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ApplyUniqueValuesWithAlternateSymbols - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ArcGISMapImageLayerUrl - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ArcGISTiledLayerUrl - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BlendRasterLayer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("BlendRasterLayer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("BrowseOGCAPIFeatureService - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/BrowseWfsLayers/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("BrowseWfsLayers - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeSublayerRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeSublayerVisibility - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateAndSaveKmlFile - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayAnnotation/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayAnnotation - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayDimensions/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayDimensions/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayDimensions - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -25,9 +25,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayFeatureLayers - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKml/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayKml - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayOgcApiFeatureCollection - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplaySubtypeFeatureLayer - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/DisplayWfsLayer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayWfsLayer - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportTiles/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ExportTiles - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportVectorTiles/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ExportVectorTiles/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ExportVectorTiles - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FeatureCollectionLayerFromPortal - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureCollectionLayerQuery - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Feature_Collection_Layer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/GroupLayers/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("GroupLayers - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Hillshade_Renderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Hillshade_Renderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IdentifyKmlFeatures - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/IdentifyRasterCell/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IdentifyRasterCell - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ListKmlContents/main.cpp
@@ -21,9 +21,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("LoadWfsXmlQuery - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/ManageOperationalLayers/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   // register the draw order model
   qmlRegisterType<DrawOrderLayerListModel>("Esri.Samples", 1, 0, "DrawOrderListModel");
   QGuiApplication app(argc, argv);

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/OSM_Layer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OSM_Layer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/PlayAKmlTour/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("QueryOGCAPICQLFilters - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterColormapRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterColormapRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionFile/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterFunctionFile - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterFunctionService/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterFunctionService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerFile/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerFile - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerGeoPackage - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterLayerService/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerService - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRenderingRule/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterRenderingRule - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterRgbRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterRgbRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/RasterStretchRenderer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterStretchRenderer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/StyleWmsLayer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("StyleWmsLayer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/TileCacheLayer/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("TileCacheLayer - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("VectorTiledLayerUrl - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WMTS_Layer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("WMTS_Layer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("Web_Tiled_Layer - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Layers/WmsLayerUrl/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("WmsLayerUrl - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ApplyScheduledMapUpdates - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("BrowseBuildingFloors - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeBasemap/main.cpp
@@ -28,9 +28,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("Test - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ChangeViewpoint/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeViewpoint - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/CreateAndSaveMap/main.cpp
@@ -28,9 +28,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayDeviceLocation - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayDeviceLocationWithNmeaDataSources - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayDrawingStatus - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayLayerViewDrawState - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayMap/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayMap - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DisplayOverviewMap/main.cpp
@@ -24,9 +24,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayOverviewMap - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DownloadPreplannedMap - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMap - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("GenerateOfflineMapBasemapByReference - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMap_Overrides - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("HonorMobileMapPackageExpiration - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/IdentifyLayers/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("IdentifyLayers - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ManageBookmarks/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ManageBookmarks - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapLoaded/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("MapLoaded - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapReferenceScale/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("MapReferenceScale - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MapRotation/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("MapRotation - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MinMaxScale/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("MobileMap_SearchAndRoute - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMapUrl/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenMapUrl - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenMobileMap_MapPackage - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ReadGeoPackage/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
 
   // Use of Esri location services, including basemaps and geocoding,

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapArea/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetInitialMapArea - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetInitialMapLocation/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetInitialMapLocation - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMapSpatialReference/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetMapSpatialReference - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMaxExtent/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/SetMaxExtent/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("SetMaxExtent - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ShowDeviceLocationUsingIndoorPositioning - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowLocationHistory/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ShowLocationHistory - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowMagnifier/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ShowMagnifier - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/TakeScreenshot/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("TakeScreenshot - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ClosestFacility/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ClosestFacility - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/DisplayRouteLayer/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayRouteLayer - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FindClosestFacilityToMultipleIncidentsService - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindRoute/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindRoute - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FindServiceAreasForMultipleFacilities - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NavigateARouteWithRerouting - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NavigateRoute - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/OfflineRouting/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("OfflineRouting - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/RouteAroundBarriers/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("RouteAroundBarriers - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/ServiceArea/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceArea - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Animate3DSymbols/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -21,9 +21,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/BasicSceneView/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ChooseCameraController/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -21,9 +21,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OpenScene/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenScene - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -21,9 +21,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SceneLayerSelection/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SurfacePlacement/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/Symbols/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/TerrainExaggeration/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context
     // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -24,9 +24,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context
   // in order to instance 3D symbols

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindAddress/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindAddress - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/FindPlace/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindPlace - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/OfflineGeocode/main.cpp
@@ -25,9 +25,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("OfflineGeocode - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -22,9 +22,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ReverseGeocodeOnline - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName("SearchDictionarySymbolStyle - QML");
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ConfigureSubnetworkTrace - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateLoadReport - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -22,9 +22,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayContentOfUtilityNetworkContainer - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayUtilityAssociations - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -20,9 +20,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("PerformValveIsolationTrace - QML"));
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -23,9 +23,6 @@
 
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("TraceUtilityNetwork - QML"));
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/mainSample.cpp
@@ -309,8 +309,6 @@ void registerCppSampleClasses();
 
 int main(int argc, char *argv[])
 {
-  QQuickWindow::setGraphicsApi(QSGRendererInterface::GraphicsApi::OpenGL);
-
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND

--- a/sample-templates/templateArcGISRuntimeSDKQt_Cpp/main.cpp.tmpl
+++ b/sample-templates/templateArcGISRuntimeSDKQt_Cpp/main.cpp.tmpl
@@ -35,9 +35,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 @endif
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   @if %{ThreeDSample}
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context

--- a/sample-templates/templateArcGISRuntimeSDKQt_Cpp_Widgets/main.cpp.tmpl
+++ b/sample-templates/templateArcGISRuntimeSDKQt_Cpp_Widgets/main.cpp.tmpl
@@ -30,9 +30,6 @@ void setAPIKey(const QApplication& app, QString apiKey);
 @endif
 int main(int argc, char *argv[])
 {
-    // Enforce OpenGL
-    qputenv("QSG_RHI_BACKEND", "opengl");
-
 @if %{ThreeDSample}
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     // Linux requires 3.2 OpenGL Context

--- a/sample-templates/templateArcGISRuntimeSDKQt_QML/main.cpp.tmpl
+++ b/sample-templates/templateArcGISRuntimeSDKQt_QML/main.cpp.tmpl
@@ -29,9 +29,6 @@ void setAPIKey(const QGuiApplication& app, QString apiKey);
 @endif
 int main(int argc, char *argv[])
 {
-  // Enforce OpenGL
-  qputenv("QSG_RHI_BACKEND", "opengl");
-
   @if %{ThreeDSample}
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
   // Linux requires 3.2 OpenGL Context


### PR DESCRIPTION
# Description

Remove the enforcement of OpenGL in the daily sample builds. This will light up Direct3D on Windows and Metal for macOS/iOS.

Same change applies to individual samples.