### PR TITLE
Revert removal of TTS

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.cpp
@@ -63,11 +63,9 @@
 #include <QList>
 #include <QStandardPaths>
 #include <QTime>
+#include <QtTextToSpeech/QTextToSpeech>
 #include <QUrl>
 #include <QUuid>
-
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// #include <QTextToSpeech>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -106,7 +104,7 @@ NavigateARouteWithRerouting::NavigateARouteWithRerouting(QObject* parent /* = nu
   }
   const QString geodatabaseLocation = folderLocation + QString("/sandiego.geodatabase");
   m_routeTask = new RouteTask(geodatabaseLocation, "Streets_ND", this);
-  // m_speaker = new QTextToSpeech(this);
+  m_speaker = new QTextToSpeech(this);
 }
 
 NavigateARouteWithRerouting::~NavigateARouteWithRerouting() = default;
@@ -231,10 +229,10 @@ void NavigateARouteWithRerouting::startNavigation()
   connectRouteTrackerSignals();
 
   // enable the RouteTracker to know when the QTextToSpeech engine is ready
-  //  m_routeTracker->setSpeechEngineReadyFunction([speaker = m_speaker]() -> bool
-  //  {
-  //    return speaker->state() == QTextToSpeech::State::Ready;
-  //  });
+  m_routeTracker->setSpeechEngineReadyFunction([speaker = m_speaker]() -> bool
+  {
+    return speaker->state() == QTextToSpeech::State::Ready;
+  });
 
   // enable "recenter" button when location display is moved from nagivation mode
   connect(m_mapView->locationDisplay(), &LocationDisplay::autoPanModeChanged, this, [this](LocationDisplayAutoPanMode autoPanMode)
@@ -273,11 +271,11 @@ void NavigateARouteWithRerouting::startNavigation()
 
 void NavigateARouteWithRerouting::connectRouteTrackerSignals()
 {
-  //  connect(m_routeTracker, &RouteTracker::newVoiceGuidance, this, [this](VoiceGuidance* rawVoiceGuidance)
-  //  {
-  //    auto voiceGuidance = std::unique_ptr<VoiceGuidance>(rawVoiceGuidance);
-  //    m_speaker->say(voiceGuidance->text());
-  //  });
+  connect(m_routeTracker, &RouteTracker::newVoiceGuidance, this, [this](VoiceGuidance* rawVoiceGuidance)
+  {
+    auto voiceGuidance = std::unique_ptr<VoiceGuidance>(rawVoiceGuidance);
+    m_speaker->say(voiceGuidance->text());
+  });
 
   connect(m_routeTracker, &RouteTracker::trackingStatusChanged, this, [this](TrackingStatus* rawTrackingStatus)
   {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.h
@@ -22,8 +22,7 @@
 #include "RouteParameters.h"
 #include "DirectionManeuver.h"
 
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// class QTextToSpeech;
+class QTextToSpeech;
 
 namespace Esri
 {
@@ -92,7 +91,7 @@ private:
   QString m_textString = "";
   Esri::ArcGISRuntime::RouteParameters m_routeParameters;
   QList<Esri::ArcGISRuntime::DirectionManeuver> m_directionManeuvers;
-  // QTextToSpeech* m_speaker = nullptr;
+  QTextToSpeech* m_speaker = nullptr;
 };
 
 #endif // NAVIGATEAROUTEWITHREROUTING_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.pro
@@ -23,9 +23,7 @@ CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
 QT += opengl qml quick
-
-# NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-# QT += texttospeech
+QT += texttospeech
 
 TEMPLATE = app
 TARGET = NavigateARouteWithRerouting

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.cpp
@@ -56,12 +56,12 @@
 #include "Graphic.h"
 #include "SimpleLineSymbol.h"
 
-#include <QUuid>
 #include <memory>
 #include <QList>
 #include <QTime>
-#include <QUrl>
 #include <QtTextToSpeech/QTextToSpeech>
+#include <QUrl>
+#include <QUuid>
 
 using namespace Esri::ArcGISRuntime;
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.cpp
@@ -61,9 +61,7 @@
 #include <QList>
 #include <QTime>
 #include <QUrl>
-
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// #include <QTextToSpeech>
+#include <QtTextToSpeech/QTextToSpeech>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -80,8 +78,7 @@ NavigateRoute::NavigateRoute(QObject* parent /* = nullptr */):
 {
   m_routeOverlay = new GraphicsOverlay(this);
   m_routeTask = new RouteTask(routeTaskUrl, this);
-
-  // m_speaker = new QTextToSpeech(this);
+  m_speaker = new QTextToSpeech(this);
 }
 
 NavigateRoute::~NavigateRoute() = default;
@@ -204,10 +201,10 @@ void NavigateRoute::startNavigation()
   connectRouteTrackerSignals();
 
   // enable the RouteTracker to know when the QTextToSpeech engine is ready
-  //  m_routeTracker->setSpeechEngineReadyFunction([speaker = m_speaker]() -> bool
-  //  {
-  //    return speaker->state() == QTextToSpeech::State::Ready;
-  //  });
+  m_routeTracker->setSpeechEngineReadyFunction([speaker = m_speaker]() -> bool
+  {
+    return speaker->state() == QTextToSpeech::State::Ready;
+  });
 
   // enable "recenter" button when location display is moved from nagivation mode
   connect(m_mapView->locationDisplay(), &LocationDisplay::autoPanModeChanged, this, [this](LocationDisplayAutoPanMode autoPanMode)
@@ -234,11 +231,11 @@ void NavigateRoute::startNavigation()
 
 void NavigateRoute::connectRouteTrackerSignals()
 {
-  //  connect(m_routeTracker, &RouteTracker::newVoiceGuidance, this, [this](VoiceGuidance* rawVoiceGuidance)
-  //  {
-  //    auto voiceGuidance = std::unique_ptr<VoiceGuidance>(rawVoiceGuidance);
-  //    m_speaker->say(voiceGuidance->text());
-  //  });
+  connect(m_routeTracker, &RouteTracker::newVoiceGuidance, this, [this](VoiceGuidance* rawVoiceGuidance)
+  {
+    auto voiceGuidance = std::unique_ptr<VoiceGuidance>(rawVoiceGuidance);
+    m_speaker->say(voiceGuidance->text());
+  });
 
   connect(m_routeTracker, &RouteTracker::trackingStatusChanged, this, [this](TrackingStatus* rawTrackingStatus)
   {

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.h
@@ -31,8 +31,7 @@ class RouteTracker;
 class SimulatedLocationDataSource;
 }
 
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// class QTextToSpeech;
+class QTextToSpeech;
 
 #include <QObject>
 #include <QString>
@@ -89,9 +88,7 @@ private:
   bool m_navigationEnabled = false;
   bool m_recenterEnabled = false;
   QString m_textString = "";
-
-  // As of Qt 6.2, QTextToSpeech is not supported
-  // QTextToSpeech* m_speaker = nullptr;
+  QTextToSpeech* m_speaker = nullptr;
 };
 
 #endif // NAVIGATEROUTE_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.pro
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/NavigateRoute/NavigateRoute.pro
@@ -23,9 +23,7 @@ CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
 QT += opengl qml quick
-
-# NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-# QT += texttospeech
+QT += texttospeech
 
 TEMPLATE = app
 TARGET = NavigateRoute

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -288,8 +288,8 @@ Rectangle {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse.accepted = true;
-            onWheel: wheel.accepted = true;
+            onPressed: mouse => mouse.accepted = true;
+            onWheel: wheel => wheel.accepted = true;
         }
 
         Column {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateARouteWithRerouting.qml
@@ -20,6 +20,7 @@ import Esri.ArcGISRuntime
 import QtQuick.Layouts
 import QtPositioning
 import Esri.ArcGISExtras
+import Esri.samples
 
 Rectangle {
     id: rootRectangle
@@ -243,20 +244,19 @@ Rectangle {
         }
 
         // Output new voice guidance
-        //        onNewVoiceGuidanceResultChanged: {
-        //            speaker.textToSpeech(newVoiceGuidanceResult.text);
-        //        }
+        onNewVoiceGuidanceResultChanged: {
+            speaker.textToSpeech(newVoiceGuidanceResult.text);
+        }
 
         // Set a callback to indicate if the speech engine is ready to speak
-        //        speechEngineReadyCallback: function() {
-        //            return speaker.textToSpeechEngineReady();
-        //        }
+        speechEngineReadyCallback: function() {
+            return speaker.textToSpeechEngineReady();
+        }
     }
 
-    // NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-    //    NavigateRouteSpeaker {
-    //        id: speaker
-    //    }
+    NavigateRouteSpeaker {
+        id: speaker
+    }
 
     function startNavigation() {
         // Solve the route with the default parameters
@@ -288,8 +288,8 @@ Rectangle {
         // Prevent mouse interaction from propagating to the MapView
         MouseArea {
             anchors.fill: parent
-            onPressed: mouse => mouse.accepted = true;
-            onWheel: wheel => wheel.accepted = true;
+            onPressed: mouse.accepted = true;
+            onWheel: wheel.accepted = true;
         }
 
         Column {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.cpp
@@ -15,13 +15,11 @@
 // [Legal]
 
 #include "NavigateRouteSpeaker.h"
-
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// #include <QTextToSpeech>
+#include <QtTextToSpeech/QTextToSpeech>
 
 NavigateRouteSpeaker::NavigateRouteSpeaker(QObject* parent):
-  QObject(parent)/*,
-  m_speaker(new QTextToSpeech(this))*/
+  QObject(parent),
+  m_speaker(new QTextToSpeech(this))
 {
 }
 
@@ -29,11 +27,10 @@ NavigateRouteSpeaker::~NavigateRouteSpeaker() = default;
 
 void NavigateRouteSpeaker::textToSpeech(const QString& text)
 {
-  // m_speaker->say(text);
+  m_speaker->say(text);
 }
 
 bool NavigateRouteSpeaker::textToSpeechEngineReady() const
 {
-  return false;
-  // return m_speaker->state() == QTextToSpeech::State::Ready;
+  return m_speaker->state() == QTextToSpeech::State::Ready;
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateARouteWithRerouting/NavigateRouteSpeaker.h
@@ -19,8 +19,7 @@
 
 #include <QObject>
 
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// class QTextToSpeech;
+class QTextToSpeech;
 class NavigateRouteSpeaker : public QObject
 {
   Q_OBJECT
@@ -32,8 +31,8 @@ public:
   Q_INVOKABLE void textToSpeech(const QString& text);
   Q_INVOKABLE bool textToSpeechEngineReady() const;
 
-  // private:
-  //   QTextToSpeech* m_speaker = nullptr;
+private:
+  QTextToSpeech* m_speaker = nullptr;
 };
 
 #endif // NAVIGATEROUTESPEAKER_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.pro
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.pro
@@ -17,7 +17,7 @@ TEMPLATE = app
 
 # additional modules are pulled in via arcgisruntime.pri
 QT += opengl qml quick
-# QT += texttospeech
+QT += texttospeech
 
 CONFIG += c++17
 

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRoute.qml
@@ -19,9 +19,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtPositioning
 import Esri.ArcGISRuntime
-
-// QTextToSpeech is not supported by Qt 6.2 so this is commented out
-// import Esri.samples
+import Esri.samples
 
 Rectangle {
     id: rootRectangle
@@ -264,22 +262,21 @@ Rectangle {
                 }
             }
 
-// output new voice guidance
-//            onNewVoiceGuidanceResultChanged: {
-//                speaker.textToSpeech(newVoiceGuidanceResult.text);
-//            }
+            // output new voice guidance
+            onNewVoiceGuidanceResultChanged: {
+                speaker.textToSpeech(newVoiceGuidanceResult.text);
+            }
 
-// set a callback to indicate if the speech engine is ready to speak
-//            speechEngineReadyCallback: function() {
-//                return speaker.textToSpeechEngineReady();
-//            }
+            // set a callback to indicate if the speech engine is ready to speak
+            speechEngineReadyCallback: function() {
+                return speaker.textToSpeechEngineReady();
+            }
         }
     }
 
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Uses of this class have been commented out for compatibility, but remain for reference
-//    NavigateRouteSpeaker {
-//        id: speaker
-//    }
+    NavigateRouteSpeaker {
+        id: speaker
+    }
 
     function startNavigation() {
         // get the directions for the route

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRouteSpeaker.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRouteSpeaker.cpp
@@ -1,23 +1,20 @@
 #include "NavigateRouteSpeaker.h"
-
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// #include <QTextToSpeech>
+#include <QtTextToSpeech/QTextToSpeech>
 
 NavigateRouteSpeaker::NavigateRouteSpeaker(QObject* parent):
-  QObject(parent)/*,
-  m_speaker(new QTextToSpeech(this))*/
+  QObject(parent),
+  m_speaker(new QTextToSpeech(this))
 {
 }
 
 NavigateRouteSpeaker::~NavigateRouteSpeaker() = default;
 
-void NavigateRouteSpeaker::textToSpeech(const QString&)
+void NavigateRouteSpeaker::textToSpeech(const QString& text)
 {
-  //  m_speaker->say(text);
+  m_speaker->say(text);
 }
 
 bool NavigateRouteSpeaker::textToSpeechEngineReady() const
 {
-  return false;
-  // return m_speaker->state() == QTextToSpeech::State::Ready;
+  return m_speaker->state() == QTextToSpeech::State::Ready;
 }

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRouteSpeaker.h
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/NavigateRouteSpeaker.h
@@ -1,8 +1,7 @@
 #ifndef NAVIGATEROUTESPEAKER_H
 #define NAVIGATEROUTESPEAKER_H
 
-// NOTE: As of Qt 6.2, QTextToSpeech is not supported. Instances of this class have been commented out for compatibility, but remain for reference
-// class QTextToSpeech;
+class QTextToSpeech;
 
 #include <QObject>
 
@@ -17,8 +16,8 @@ public:
   Q_INVOKABLE void textToSpeech(const QString& text);
   Q_INVOKABLE bool textToSpeechEngineReady() const;
 
-// private:
-//   QTextToSpeech* m_speaker = nullptr;
+private:
+  QTextToSpeech* m_speaker = nullptr;
 };
 
 #endif // NAVIGATEROUTESPEAKER_H

--- a/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Routing/NavigateRoute/main.cpp
@@ -18,7 +18,7 @@
 #include <QDir>
 #include <QQmlEngine>
 
-// #include "NavigateRouteSpeaker.h"
+#include "NavigateRouteSpeaker.h"
 
 int main(int argc, char *argv[])
 {
@@ -48,8 +48,7 @@ int main(int argc, char *argv[])
   view.setResizeMode(QQuickView::SizeRootObjectToView);
 
   // Register the C++ NavigateRouteSpeaker class
-  // -- QTextToSpeech is not supported by Qt 6.2, so this is commented out --
-  // qmlRegisterType<NavigateRouteSpeaker>("Esri.samples", 1, 0, "NavigateRouteSpeaker");
+  qmlRegisterType<NavigateRouteSpeaker>("Esri.samples", 1, 0, "NavigateRouteSpeaker");
 
   // Add the import Path
   view.engine()->addImportPath(QDir(QCoreApplication::applicationDirPath()).filePath("qml"));

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -19,7 +19,7 @@
 
 TEMPLATE = app
 QT += core gui xml network qml quick positioning sensors multimedia
-QT += widgets quickcontrols2 opengl webview core5compat websockets
+QT += widgets quickcontrols2 opengl webview core5compat websockets texttospeech
 TARGET = ArcGISQt_CppSamples
 DEFINES += CPP_VIEWER
 DEFINES += Qt_Version=\"$$QT_VERSION\"

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
@@ -11,7 +11,7 @@
 
 TEMPLATE = app
 QT += core gui xml network qml quick positioning sensors multimedia
-QT += widgets quickcontrols2 opengl webview core5compat websockets
+QT += widgets quickcontrols2 opengl webview core5compat websockets texttospeech
 TARGET = ArcGISQt_QMLSamples
 DEFINES += QML_VIEWER
 DEFINES += Qt_Version=\"$$QT_VERSION\"


### PR DESCRIPTION
# Description

Adds TextToSpeech back to navigation samples because it's a part of Qt 6.5. Changes tested on macOS with standalone samples and sample viewers.

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
