### PR TITLE
Use the last location in the list of PicturesLocation

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.qml
@@ -217,7 +217,10 @@ EditFeatureAttachmentsSample {
     // file dialog for selecting a file to add as an attachment
     FileDialog {
         id: fileDialog
-        folder: StandardPaths.standardLocations(StandardPaths.PicturesLocation)[0] ?? ""
+        folder: {
+            const locs = StandardPaths.standardLocations(StandardPaths.PicturesLocation)
+            return locs.length > 0 ? locs[locs.length - 1] : "";
+        }
         onAccepted: {
             // Call invokable C++ method to add an attachment to the model
             editAttachmentsSample.addAttachment(fileDialog.file, "application/octet-stream");


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

The Cpp version of EditAttachmentsDialog was using the first location in the list of PicturesLocation folders. The QML version has been using the last location. This discrepancy caused no problems up through Qt 6.2. Something changed in Qt 6.5 -- either more items are being returned in that list, or they are in a different order. Either way, the Cpp version started bringing up the iCloud file browser rather than the Photos browser. The Cpp version has been changed to match the Qml version so that it goes back to bringing up the Photos browser.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
