### PR TITLE
Disable the location display when switching between samples.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
@@ -48,7 +48,10 @@ ShowDeviceLocationUsingIndoorPositioning::ShowDeviceLocationUsingIndoorPositioni
   m_map = new Map(new PortalItem(itemId, this), this);
 }
 
-ShowDeviceLocationUsingIndoorPositioning::~ShowDeviceLocationUsingIndoorPositioning() = default;
+ShowDeviceLocationUsingIndoorPositioning::~ShowDeviceLocationUsingIndoorPositioning()
+{
+  m_mapView->locationDisplay()->stop();
+}
 
 void ShowDeviceLocationUsingIndoorPositioning::init()
 {

--- a/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
+++ b/ArcGISRuntimeSDKQt_QMLSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
@@ -43,6 +43,10 @@ Rectangle {
             forceActiveFocus();
         }
 
+        Component.onDestruction: {
+            mapView.locationDisplay.stop();
+        }
+
         Map {
             id: map
             PortalItem {


### PR DESCRIPTION
Workaround for an internal timer problem.

# Description

Same workaround as https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/1234. I tested locally on iOS with the QML sample app viewer and it no longer crashes when switching away from the indoors sample.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [X] iOS

