### PR TITLE
The MapView is not declared within the QML sample.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
@@ -48,7 +48,9 @@ ShowDeviceLocationUsingIndoorPositioning::ShowDeviceLocationUsingIndoorPositioni
   m_map = new Map(new PortalItem(itemId, this), this);
 }
 
-ShowDeviceLocationUsingIndoorPositioning::~ShowDeviceLocationUsingIndoorPositioning()
+ShowDeviceLocationUsingIndoorPositioning::~ShowDeviceLocationUsingIndoorPositioning() = default;
+
+void ShowDeviceLocationUsingIndoorPositioning::stopLocationDisplay()
 {
   m_mapView->locationDisplay()->stop();
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.h
@@ -45,6 +45,8 @@ public:
 
   static void init();
 
+  Q_INVOKABLE void stopLocationDisplay();
+
 signals:
   void mapViewChanged();
   void locationPropertiesChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.qml
@@ -30,6 +30,10 @@ Item {
             // Set and keep the focus on MapView to enable keyboard navigation
             forceActiveFocus();
         }
+
+        Component.onDestruction: {
+            model.stopLocationDisplay();
+        }
     }
 
     Rectangle {


### PR DESCRIPTION
We need to make sure the destruction order is like we expect.

# Description

This sample is different than the others that use this workaround. In the others, the QML is declared like this:
```qml
MyCoolSample {
    MapView { ...
```

But this one is:
```qml
Item {
    MapView { ... }

    ShowDeviceLocationUsingIndoorPositioningSample {
        id: model
        mapView: view
    }
}
```

So the sample's lifetime is not tied to the MapView's lifetime. It was crashing because the MapView was partially destructed when we get to the sample's destructor.

I tested this new fix on both macOS and iOS.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

- [ ] Windows
- [ ] Android
- [ ] Linux
- [X] macOS
- [X] iOS
