### PR TITLE
implicit width

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/LocalServer/LocalServerServices/LocalServerServices.qml
@@ -91,7 +91,6 @@ LocalServerServicesSample {
             Button {
                 id: fileDialogButton
                 text: "..."
-                width: 30
                 enabled: isServerRunning
 
                 onClicked: {


### PR DESCRIPTION
# Description
Use implicit width on the button to ensure text is always displayed. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [x] If adding a new sample, it is added to the sample viewer
- [x] Cherry-picked to Main branch (if applicable)



![image](https://github.com/Esri/arcgis-maps-sdk-samples-qt/assets/105450339/f53c9964-5c43-42c8-818b-e6db22d983c9)
