### PR TITLE
Bri12415/q future samples

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
@@ -77,8 +77,6 @@ void ShowPopup::setMapView(MapQuickView* mapView)
   // once map is set, connect to MapQuickView mouse clicked signal
   connect(m_mapView, &MapQuickView::mouseClicked, this, &ShowPopup::onMouseClicked);
 
-  // connect to MapQuickView::identifyLayerCompleted signal
-  connect(m_mapView, &MapQuickView::identifyLayerCompleted, this, &ShowPopup::onIdentifyLayerCompleted);
   emit mapViewChanged();
 }
 
@@ -137,17 +135,22 @@ void ShowPopup::onMouseClicked(QMouseEvent& mouseEvent)
   constexpr bool returnPopupsOnly = false;
   constexpr int maximumResults = 10;
 
-  m_taskWatcher = m_mapView->identifyLayer(m_featureLayer, mouseEvent.position().x(), mouseEvent.position().y(), tolerance, returnPopupsOnly, maximumResults);
+  m_future = m_mapView->identifyLayerAsync(m_featureLayer, mouseEvent.position(), tolerance, returnPopupsOnly, maximumResults);
+  m_future.then(this, [this](IdentifyLayerResult* result)
+  {
+    //TODOB: Do i need to check any conditions on the future before calling this? Probably applies to all QFuture replacements
+    onIdentifyLayerCompleted(QUuid(),result);
+  });
 
-  if (!m_taskWatcher.isValid())
-    qWarning() << "Task not valid.";
+  if (!m_future.isValid())
+    qWarning() << "Future not valid.";
 
   emit taskRunningChanged();
 }
 
 bool ShowPopup::taskRunning() const
 {
-  return !m_taskWatcher.isDone();
+  return !m_future.isFinished();
 }
 
 QQmlListProperty<PopupManager> ShowPopup::popupManagers()

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.cpp
@@ -138,7 +138,6 @@ void ShowPopup::onMouseClicked(QMouseEvent& mouseEvent)
   m_future = m_mapView->identifyLayerAsync(m_featureLayer, mouseEvent.position(), tolerance, returnPopupsOnly, maximumResults);
   m_future.then(this, [this](IdentifyLayerResult* result)
   {
-    //TODOB: Do i need to check any conditions on the future before calling this? Probably applies to all QFuture replacements
     onIdentifyLayerCompleted(QUuid(),result);
   });
 

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.h
@@ -17,9 +17,6 @@
 #ifndef SHOWPOPUP_H
 #define SHOWPOPUP_H
 
-// C++ API headers
-#include "TaskWatcher.h"
-
 namespace Esri::ArcGISRuntime
 {
 class FeatureLayer;
@@ -30,10 +27,13 @@ class MapQuickView;
 class PopupManager;
 }
 
+
 #include <QObject>
 #include <QQmlListProperty>
 #include <QMouseEvent>
+#include <QFuture>
 #include <QUuid>
+
 
 Q_MOC_INCLUDE("MapQuickView.h")
 Q_MOC_INCLUDE("PopupManager.h")
@@ -75,7 +75,7 @@ private:
   QList<Esri::ArcGISRuntime::PopupManager*> m_popupManagers;
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
 
-  Esri::ArcGISRuntime::TaskWatcher m_taskWatcher;
+  QFuture<Esri::ArcGISRuntime::IdentifyLayerResult*> m_future;
 };
 
 #endif // SHOWPOPUP_H

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/ShowPopup/ShowPopup.h
@@ -27,13 +27,11 @@ class MapQuickView;
 class PopupManager;
 }
 
-
 #include <QObject>
 #include <QQmlListProperty>
 #include <QMouseEvent>
 #include <QFuture>
 #include <QUuid>
-
 
 Q_MOC_INCLUDE("MapQuickView.h")
 Q_MOC_INCLUDE("PopupManager.h")

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.cpp
@@ -96,7 +96,7 @@ MapQuickView* FindServiceAreasForMultipleFacilities::mapView() const
 
 bool FindServiceAreasForMultipleFacilities::taskRunning() const
 {
-  return !m_taskWatcher.isDone();
+  return !m_future.isFinished();
 }
 
 // Set the view (created in QML)
@@ -159,27 +159,28 @@ void FindServiceAreasForMultipleFacilities::connectServiceAreaTaskSignals()
     // add all facilities to the service area parameters
     serviceAreaParameters.setFacilitiesWithFeatureTable(m_facilitiesTable, queryParameters);
 
-    m_taskWatcher = m_serviceAreaTask->solveServiceArea(serviceAreaParameters);
-    if (!m_taskWatcher.isValid())
+    m_future = m_serviceAreaTask->solveServiceAreaAsync(serviceAreaParameters);
+
+    m_future.then(this, [this](const ServiceAreaResult& serviceAreaResult)
+    {
+      emit taskRunningChanged();
+
+      // iterate through the facilities to get the service area polygons
+      for (int i = 0; i < serviceAreaResult.facilities().size(); ++i)
+      {
+        QList<ServiceAreaPolygon> serviceAreaPolygonList = serviceAreaResult.resultPolygons(i);
+        // create a graphic for each available polygon
+        for (int j = 0; j < serviceAreaPolygonList.size(); ++j)
+        {
+          m_serviceAreasOverlay->graphics()->append(new Graphic(serviceAreaPolygonList[j].geometry(), m_fillSymbols[j], this));
+        }
+      }
+    });
+
+    if (!m_future.isValid())
       qWarning() << "Task not valid.";
 
     emit taskRunningChanged();
-  });
-
-  connect(m_serviceAreaTask, &ServiceAreaTask::solveServiceAreaCompleted, this, [this](const QUuid&, const ServiceAreaResult& serviceAreaResult)
-  {
-    emit taskRunningChanged();
-
-    // iterate through the facilities to get the service area polygons
-    for (int i = 0; i < serviceAreaResult.facilities().size(); ++i)
-    {
-      QList<ServiceAreaPolygon> serviceAreaPolygonList = serviceAreaResult.resultPolygons(i);
-      // create a graphic for each available polygon
-      for (int j = 0; j < serviceAreaPolygonList.size(); ++j)
-      {
-        m_serviceAreasOverlay->graphics()->append(new Graphic(serviceAreaPolygonList[j].geometry(), m_fillSymbols[j], this));
-      }
-    }
   });
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.cpp
@@ -160,7 +160,6 @@ void FindServiceAreasForMultipleFacilities::connectServiceAreaTaskSignals()
     serviceAreaParameters.setFacilitiesWithFeatureTable(m_facilitiesTable, queryParameters);
 
     m_future = m_serviceAreaTask->solveServiceAreaAsync(serviceAreaParameters);
-
     m_future.then(this, [this](const ServiceAreaResult& serviceAreaResult)
     {
       emit taskRunningChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.h
@@ -17,7 +17,7 @@
 #ifndef FINDSERVICEAREASFORMULTIPLEFACILITIES_H
 #define FINDSERVICEAREASFORMULTIPLEFACILITIES_H
 
-#include "TaskWatcher.h"
+#include "ServiceAreaResult.h"
 
 namespace Esri::ArcGISRuntime
 {
@@ -25,11 +25,13 @@ class FeatureLayer;
 class GraphicsOverlay;
 class Map;
 class MapQuickView;
+class ServiceAreaResult;
 class ServiceAreaTask;
 class ServiceFeatureTable;
 class SimpleFillSymbol;
 }
 
+#include <QFuture>
 #include <QObject>
 
 Q_MOC_INCLUDE("MapQuickView.h")
@@ -67,7 +69,8 @@ private:
   Esri::ArcGISRuntime::ServiceFeatureTable* m_facilitiesTable = nullptr;
   QList<Esri::ArcGISRuntime::SimpleFillSymbol*> m_fillSymbols;
   bool m_taskRunning = false;
-  Esri::ArcGISRuntime::TaskWatcher m_taskWatcher;
+
+  QFuture<Esri::ArcGISRuntime::ServiceAreaResult> m_future;
 };
 
 #endif // FINDSERVICEAREASFORMULTIPLEFACILITIES_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/FindServiceAreasForMultipleFacilities/FindServiceAreasForMultipleFacilities.h
@@ -69,7 +69,6 @@ private:
   Esri::ArcGISRuntime::ServiceFeatureTable* m_facilitiesTable = nullptr;
   QList<Esri::ArcGISRuntime::SimpleFillSymbol*> m_fillSymbols;
   bool m_taskRunning = false;
-
   QFuture<Esri::ArcGISRuntime::ServiceAreaResult> m_future;
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Routing/OfflineRouting/OfflineRouting.h
@@ -19,7 +19,7 @@
 
 #include "Envelope.h"
 #include "RouteParameters.h"
-#include "TaskWatcher.h"
+#include "RouteResult.h"
 
 namespace Esri::ArcGISRuntime
 {
@@ -31,6 +31,7 @@ class PictureMarkerSymbol;
 class RouteTask;
 }
 
+#include <QFuture>
 #include <QObject>
 
 Q_MOC_INCLUDE("MapQuickView.h")
@@ -76,7 +77,7 @@ private:
   Esri::ArcGISRuntime::GraphicsOverlay* m_routeOverlay = nullptr;
   Esri::ArcGISRuntime::RouteTask* m_routeTask = nullptr;
   Esri::ArcGISRuntime::RouteParameters m_routeParameters;
-  Esri::ArcGISRuntime::TaskWatcher m_taskWatcher;
+  QFuture<Esri::ArcGISRuntime::RouteResult> m_future;
   int m_travelModeIndex = -1;
   Esri::ArcGISRuntime::Envelope m_routableArea;
 };


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->
Replace m_taskwatcher fields with m_future and replace relevant signal/slot logic with qfuture mechanics
## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
