### PR TITLE
Aji13187/qt653 error

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/CppSampleManager.h
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/CppSampleManager.h
@@ -39,7 +39,7 @@ public:
   ~CppSampleManager() override;
 
   void init() override;
-  Q_INVOKABLE void clearCredentialCache() override;
+  void clearCredentialCache() override;
 
 protected:
   QString api() const override;

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/QmlSampleManager.h
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/QmlSampleManager.h
@@ -28,7 +28,7 @@ public:
   explicit QmlSampleManager(QQmlEngine* engine, QObject* parent = nullptr);
   ~QmlSampleManager() override;
 
-  Q_INVOKABLE void clearCredentialCache() override;
+  void clearCredentialCache() override;
 
 protected:
   QString api() const override;

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/DownloadSampleManager.h
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/DownloadSampleManager.h
@@ -111,7 +111,7 @@ protected:
    * Clears any cached named user credentials so apps that use named user
    * workflows will prompt a challenge each time they are opened.
    */
-  virtual void clearCredentialCache() = 0;
+  Q_INVOKABLE virtual void clearCredentialCache() = 0;
 
   /*!
    * \brief Calls the load function on the internal portal.


### PR DESCRIPTION
# Description
In the base class (`DownloadSampleManager.h`) the overriden function - `clearCredentialCache()` was not marked as Q_INVOKABLE.

<!--- Summary of the change and any relevant info. -->
Issue: https://devtopia.esri.com/runtime/qt-common/issues/8657

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS




## Checklist
issue: https://devtopia.esri.com/runtime/qt-common/issues/8657

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
