### PR TITLE
Extras import path is added for CppSamplesApp

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -134,7 +134,7 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
   # Add plugin paths to QMLPATHS
   QMLPATHS += $${ARCGIS_RUNTIME_IMPORT_PATH}
 
-  # Set ArcGIS Runtime QML API Path
+  # Set ArcGIS Runtime QML import path for ArcGISExtras
   DEFINES += ARCGIS_RUNTIME_IMPORT_PATH=\"$$ARCGIS_RUNTIME_IMPORT_PATH\"
   DEFINES += BUILD_FROM_SETUP
 }

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -96,9 +96,6 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
     contains(QT_ARCH, x86_64):{
       PLATFORM = "windows/x64"
     }
-    else {
-      PLATFORM = "windows/x86"
-    }
     ARCGIS_RUNTIME_IMPORT_PATH = $${priLocation}/sdk/$${PLATFORM}/qml
   }
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -76,6 +76,66 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
       $$priLocation/sdk/include \
       $$priLocation/sdk/include/LocalServer
 
+  PLATFORM = ""
+  unix:!macx:!android:!ios {
+    contains(QMAKE_TARGET.arch, x86):{
+      PLATFORM = "linux/x86"
+    }
+    else {
+      PLATFORM = "linux/x64"
+    }
+    ARCGIS_RUNTIME_IMPORT_PATH = $${priLocation}/sdk/$${PLATFORM}/qml
+  }
+
+  macx:{
+    PLATFORM = "macOS"
+    ARCGIS_RUNTIME_IMPORT_PATH = $${priLocation}/sdk/$${PLATFORM}/universal/qml
+  }
+
+  win32:{
+    contains(QT_ARCH, x86_64):{
+      PLATFORM = "windows/x64"
+    }
+    else {
+      PLATFORM = "windows/x86"
+    }
+    ARCGIS_RUNTIME_IMPORT_PATH = $${priLocation}/sdk/$${PLATFORM}/qml
+  }
+
+  android {
+    PLATFORM = "android"
+
+    equals(QT_ARCH, "arm64-v8a") {
+        ANDROID_ARCH_FOLDER="android_arm64_v8a"
+    }
+    else:equals(QT_ARCH, "armeabi-v7a") {
+        ANDROID_ARCH_FOLDER="android_armv7"
+    }
+    else:equals(QT_ARCH, "x86") {
+        ANDROID_ARCH_FOLDER="android_x86"
+    }
+    contains(QMAKE_HOST.os, Windows):{
+      ANDROIDDIR = $$clean_path($$(ALLUSERSPROFILE)\\EsriRuntimeQt)
+      ARCGIS_RUNTIME_IMPORT_PATH = $${ANDROIDDIR}/Qt$${ARCGIS_RUNTIME_VERSION}/$${PLATFORM}/$${ANDROID_ARCH_FOLDER}/qml
+    }
+    else {
+      ARCGIS_RUNTIME_IMPORT_PATH = $${priLocation}/sdk/$${PLATFORM}/$${ANDROID_ARCH_FOLDER}/qml
+    }
+  }
+
+  ios {
+    PLATFORM = "iOS"
+    ARCGIS_RUNTIME_IMPORT_PATH = $${priLocation}/sdk/$${PLATFORM}/universal/qml
+  }
+
+  # Add plugin paths to QML_IMPORT_PATH
+  QML_IMPORT_PATH += $${ARCGIS_RUNTIME_IMPORT_PATH}
+
+  # Add plugin paths to QMLPATHS
+  QMLPATHS += $${ARCGIS_RUNTIME_IMPORT_PATH}
+
+  # Set ArcGIS Runtime QML API Path
+  DEFINES += ARCGIS_RUNTIME_IMPORT_PATH=\"$$ARCGIS_RUNTIME_IMPORT_PATH\"
   DEFINES += BUILD_FROM_SETUP
 }
 


### PR DESCRIPTION
# Description

Issue - N/A

This is the same changes made for CppFunctionalTestApp.
`message()` to print platform and arch is removed since it is already there in arcgis_runtime_qml_cpp.pri

Testing on other platforms are in progress.
This issue is not reproducible for QMLSamplesApp.
<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
