### PR TITLE
Fix for symbols not displayed - task watcher version.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.cpp
@@ -86,7 +86,7 @@ void CreateSymbolStylesFromWebStyles::createSymbolStyles()
 
       // We pass symbolStyle as the QObject parent for fetchSymbol() because we don't need access to the resulting class outside the lifetime of this SymbolStyle
       SymbolStyleSearchResultSymbolFetcher* symbolFetcher = symbolStyleSearchResult.fetchSymbol(symbolStyle);
-
+      symbolFetcher->fetchSymbol();
       connect(symbolFetcher, &SymbolStyleSearchResultSymbolFetcher::fetchSymbolCompleted, this, [this, symbolLabel, categoriesMap](const QUuid& /* taskId */, Symbol* symbol)
       {
         // If multiple field names are set, we can pass multiple values from each field,

--- a/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.cpp
@@ -86,7 +86,6 @@ void CreateSymbolStylesFromWebStyles::createSymbolStyles()
 
       // We pass symbolStyle as the QObject parent for fetchSymbol() because we don't need access to the resulting class outside the lifetime of this SymbolStyle
       SymbolStyleSearchResultSymbolFetcher* symbolFetcher = symbolStyleSearchResult.fetchSymbol(symbolStyle);
-      symbolFetcher->fetchSymbol();
       connect(symbolFetcher, &SymbolStyleSearchResultSymbolFetcher::fetchSymbolCompleted, this, [this, symbolLabel, categoriesMap](const QUuid& /* taskId */, Symbol* symbol)
       {
         // If multiple field names are set, we can pass multiple values from each field,
@@ -97,6 +96,7 @@ void CreateSymbolStylesFromWebStyles::createSymbolStyles()
           m_uniqueValueRenderer->uniqueValues()->append(new UniqueValue(symbolLabel, "", {category}, symbol, this));
         }
       });
+      symbolFetcher->fetchSymbol();
     }
   });
 


### PR DESCRIPTION
# Description

Fix for symbols are not displayed in Create symbol styles from web styles sample when built with build 4065 setup and main branch from samples and toolkit #8688

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
