### PR TITLE
Fix crash.

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -319,7 +319,7 @@ void OfflineGeocode::onGeocodingCompleted_(const QList<GeocodeResult>& geocodeRe
   m_pinGraphic->setVisible(false);
 
   // if there are no matching results, notify user and stop processing
-  if (geocodeResults.empty())
+  if (geocodeResults.isEmpty())
   {
     m_noResults = true;
     emit noResultsChanged();

--- a/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Search/OfflineGeocode/OfflineGeocode.cpp
@@ -314,18 +314,21 @@ void OfflineGeocode::onGeocodingCompleted_(const QList<GeocodeResult>& geocodeRe
   m_geocodeInProgress = false;
   emit geocodeInProgressChanged();
 
-  // if there are no matching results, notify user
+  // dismiss callouts
+  m_calloutData->setVisible(false);
+  m_pinGraphic->setVisible(false);
+
+  // if there are no matching results, notify user and stop processing
   if (geocodeResults.empty())
   {
     m_noResults = true;
     emit noResultsChanged();
+    return;
   }
+
   // dismiss no results notification
   m_noResults = false;
   emit noResultsChanged();
-
-  // dismiss callouts
-  m_calloutData->setVisible(false);
 
   // zoom to result's extent
   m_mapView->setViewpointCenterAsync(geocodeResults.at(0).displayLocation());


### PR DESCRIPTION
I shuffled around some existing code to be sure we handle the "no results" case visually as well, by clearing out any existing callout and graphic pin that was already placed from a previous geocode.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->
- [x] macOS

