### PR TITLE
Don't delete objects with pending tasks

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Maps/ApplyScheduledMapUpdates/ApplyScheduledMapUpdates.cpp
@@ -213,10 +213,6 @@ void ApplyScheduledMapUpdates::onMmpkDoneLoading(const Error& e)
   m_map = m_mobileMapPackage->maps().at(0);
   setMapToMapView();
 
-  // setup sync task
-  if (m_offlineSyncTask)
-    delete m_offlineSyncTask;
-
   m_offlineSyncTask = new OfflineMapSyncTask(m_map, this);
 
   // check for updates


### PR DESCRIPTION
# Description

This function can be code from multiple code paths. If you get the timing right, you can delete the object at the same time the callback is invoked. On macOS platforms and not others (for whatever reason), it would hit problems when this happened.

This object has a parent, so there's no need to clean it up sooner than necessary in this case. Ideally the sample code should be refactored to disallow reentering this function, but I want to keep the fix simple for now.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
