### PR TITLE
Updating the Change Renderer button functionality

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
@@ -90,10 +90,19 @@ bool FeatureLayerChangeRenderer::layerInitialized() const
 
 void FeatureLayerChangeRenderer::changeRenderer()
 {
+  if(m_stateChanged)
+  {
+    m_featureLayer->resetRenderer();
+    m_stateChanged = false;
+  }
+  else
+  {
   // create a line symbol
   SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(0, 0, 255, 204), 2.0f, this);
   // create a renderer with the symbol above
   SimpleRenderer* simpleRenderer = new SimpleRenderer(sls, this);
   // change the renderer with the renderer created above
   m_featureLayer->setRenderer(simpleRenderer);
+  m_stateChanged = true;
+  }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
@@ -90,7 +90,7 @@ bool FeatureLayerChangeRenderer::layerInitialized() const
 
 void FeatureLayerChangeRenderer::changeRenderer()
 {
-  if(m_stateChanged)
+  if (m_stateChanged)
   {
     m_featureLayer->resetRenderer();
     m_stateChanged = false;

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.cpp
@@ -97,12 +97,12 @@ void FeatureLayerChangeRenderer::changeRenderer()
   }
   else
   {
-  // create a line symbol
-  SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(0, 0, 255, 204), 2.0f, this);
-  // create a renderer with the symbol above
-  SimpleRenderer* simpleRenderer = new SimpleRenderer(sls, this);
-  // change the renderer with the renderer created above
-  m_featureLayer->setRenderer(simpleRenderer);
-  m_stateChanged = true;
+    // create a line symbol
+    SimpleLineSymbol* sls = new SimpleLineSymbol(SimpleLineSymbolStyle::Solid, QColor(0, 0, 255, 204), 2.0f, this);
+    // create a renderer with the symbol above
+    SimpleRenderer* simpleRenderer = new SimpleRenderer(sls, this);
+    // change the renderer with the renderer created above
+    m_featureLayer->setRenderer(simpleRenderer);
+    m_stateChanged = true;
   }
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Features/FeatureLayerChangeRenderer/FeatureLayerChangeRenderer.h
@@ -51,6 +51,7 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
   bool m_initialized = false;
+  bool m_stateChanged = false;
 };
 
 #endif // FEATURE_LAYER_CHANGE_RENDERER_H


### PR DESCRIPTION
# Description

This PR updates the functionality of the `Change Renderer` button in **Feature layer change renderer** sample to switch between renderers when clicked

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

