### PR TITLE
add android x86_64

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -111,6 +111,9 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
     else:equals(QT_ARCH, "x86") {
         ANDROID_ARCH_FOLDER="android_x86"
     }
+    else:equals(QT_ARCH, "x64") {
+        ANDROID_ARCH_FOLDER="android_x64"
+    }
     contains(QMAKE_HOST.os, Windows):{
       ANDROIDDIR = $$clean_path($$(ALLUSERSPROFILE)\\EsriRuntimeQt)
       ARCGIS_RUNTIME_IMPORT_PATH = $${ANDROIDDIR}/Qt$${ARCGIS_RUNTIME_VERSION}/$${PLATFORM}/$${ANDROID_ARCH_FOLDER}/qml

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -112,7 +112,7 @@ exists($$PWD/../../../../DevBuildCpp.pri) {
         ANDROID_ARCH_FOLDER="android_x86"
     }
     else:equals(QT_ARCH, "x64") {
-        ANDROID_ARCH_FOLDER="android_x64"
+        ANDROID_ARCH_FOLDER="android_x86_64"
     }
     contains(QMAKE_HOST.os, Windows):{
       ANDROIDDIR = $$clean_path($$(ALLUSERSPROFILE)\\EsriRuntimeQt)


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Add Android_x86_64 support.

Nothing to change for QML samples.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [x] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
