### PR TITLE
Fix portal user info sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.cpp
@@ -90,7 +90,7 @@ bool PortalUserInfo::loaded()
 bool PortalUserInfo::loginDismissed()
 {
   if (m_portal)
-    return m_portal->loadError().message() == "Code unauthorized.";
+    return m_portal->loadError().message() == "Code unauthorized." || m_portal->loadError().message() == "User canceled error.";
 
   return false;
 }


### PR DESCRIPTION
# Description

This PR is to fix OAuth window dismiss functionality in Portal user info sample when `Cancel` is clicked

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

