### PR TITLE
retry load if failed

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
@@ -144,10 +144,10 @@ void AddItemsToPortal::authenticatePortal()
 {
   if (!m_portal)
     return;
-  if (m_portal->loadStatus() == LoadStatus::NotLoaded)
-    m_portal->load();
-  else if (m_portal->loadStatus() == LoadStatus::FailedToLoad)
+  if (m_portal->loadStatus() == LoadStatus::FailedToLoad)
     m_portal->retryLoad();
+  else
+    m_portal->load();
 }
 
 void AddItemsToPortal::addItem()

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
@@ -142,8 +142,12 @@ bool AddItemsToPortal::busy() const
 
 void AddItemsToPortal::authenticatePortal()
 {
-  if (m_portal)
+  if (!m_portal)
+    return;
+  if (m_portal->loadStatus() == LoadStatus::NotLoaded)
     m_portal->load();
+  else if (m_portal->loadStatus() == LoadStatus::FailedToLoad)
+    m_portal->retryLoad();
 }
 
 void AddItemsToPortal::addItem()


### PR DESCRIPTION
# Description

Per the `loadable` doc

> If it has already failed to load, you can call retryLoad(). The loadStatus() property reflects the status of the load operation.

If the user closes the auth window, the load state of the Portal goes to `LoadStatus::failedToLoad`, so subsequent calls to `load()` do nothing.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
