### PR TITLE
Fix for wrong busy indicator for ShowOrgBasemaps

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
@@ -62,8 +62,10 @@ void ShowOrgBasemaps::componentComplete()
     connect(m_portal, &Portal::loadStatusChanged, this, [this]()
     {
       m_portalLoaded = m_portal->loadStatus() == LoadStatus::Loaded;
+      m_portalLoading = m_portal->loadStatus() == LoadStatus::Loading;
 
       emit portalLoadedChanged();
+      emit portalLoadingChanged();
       emit orgNameChanged();
 
       if (m_portalLoaded)
@@ -84,6 +86,11 @@ void ShowOrgBasemaps::componentComplete()
 bool ShowOrgBasemaps::portalLoaded() const
 {
   return m_portalLoaded;
+}
+
+bool ShowOrgBasemaps::portalLoading() const
+{
+  return m_portalLoading;
 }
 
 QString ShowOrgBasemaps::orgName() const
@@ -110,12 +117,20 @@ void ShowOrgBasemaps::load(bool anonymous)
     return;
 
   if (anonymous)
-    m_portal->load();
+    load();
   else {
     Credential* cred = new Credential(OAuthClientInfo("iLkGIj0nX8A4EJda", OAuthMode::User), this);
     m_portal->setCredential(cred);
-    m_portal->load();
+    load();
   }
+}
+
+void ShowOrgBasemaps::load()
+{
+  if (m_portal->loadStatus() == LoadStatus::FailedToLoad)
+    m_portal->retryLoad();
+  else
+    m_portal->load();
 }
 
 void ShowOrgBasemaps::loadSelectedBasemap(int index)

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
@@ -33,6 +33,7 @@ class ShowOrgBasemaps : public QQuickItem
   Q_OBJECT
 
   Q_PROPERTY(bool portalLoaded READ portalLoaded NOTIFY portalLoadedChanged)
+  Q_PROPERTY(bool portalLoading READ portalLoading NOTIFY portalLoadingChanged)
   Q_PROPERTY(QString orgName READ orgName NOTIFY orgNameChanged)
   Q_PROPERTY(QAbstractListModel* basemaps READ basemaps NOTIFY basemapsChanged)
   Q_PROPERTY(QString mapLoadError READ mapLoadError NOTIFY mapLoadErrorChanged)
@@ -45,6 +46,7 @@ public:
   static void init();
 
   bool portalLoaded() const;
+  bool portalLoading() const;
   QString orgName() const;
   QAbstractListModel* basemaps() const;
   QString mapLoadError() const;
@@ -55,15 +57,19 @@ public:
 
 signals:
   void portalLoadedChanged();
+  void portalLoadingChanged();
   void orgNameChanged();
   void basemapsChanged();
   void mapLoadErrorChanged();
 
 private:
+  void load();
+
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::Portal* m_portal = nullptr;
   bool m_portalLoaded = false;
+  bool m_portalLoading = false;
   QString m_mapLoadError;
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -28,7 +28,7 @@ ShowOrgBasemapsSample {
 
     BusyIndicator {
         anchors.centerIn: parent
-        running: !mapView.visible && !portalLoaded & !anonymousLogIn.visible
+        running: portalLoading
     }
 
     Text {
@@ -199,11 +199,10 @@ ShowOrgBasemapsSample {
         }
         text: "Anonymous"
         icon.source: "qrc:/Samples/CloudAndPortal/ShowOrgBasemaps/ic_menu_help_dark.png"
+        visible: !portalLoaded
 
         onClicked: {
             load(true);
-            anonymousLogIn.visible = false;
-            userLogIn.visible = false;
         }
     }
 
@@ -217,11 +216,12 @@ ShowOrgBasemapsSample {
         width: anonymousLogIn.width
         text: "Sign-in"
         icon.source: "qrc:/Samples/CloudAndPortal/ShowOrgBasemaps/ic_menu_account_dark.png"
+        visible: !portalLoaded
 
         onClicked: {
             load(false);
-            anonymousLogIn.visible = false;
-            userLogIn.visible = false;
+            // Once user Sign-in credentails provided or failed, then click on anonymousLogIn will prompt for signin. so disable it.
+            anonymousLogIn.enabled = false;
         }
     }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -220,7 +220,6 @@ ShowOrgBasemapsSample {
 
         onClicked: {
             load(false);
-            // Once user Sign-in credentails provided or failed, then click on anonymousLogIn will prompt for signin. so disable it.
             anonymousLogIn.enabled = false;
         }
     }


### PR DESCRIPTION
# Description

The busy indicator running status is modified to fix the issue with ShowOrgBasemaps.
Also portal retryLoad is added to work even if we the first load failed.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
