### PR TITLE
Change signal names in Validate UN topology sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.cpp
@@ -120,7 +120,7 @@ void ValidateUtilityNetworkTopology::setMapView(MapQuickView* mapView)
     return;
 
   m_busy = true;
-  emit isBusy();
+  emit busyStateChanged();
   updateMessage("Loading a webmap...");
 
   const Envelope envelope(
@@ -211,7 +211,7 @@ void ValidateUtilityNetworkTopology::connectSignals()
       m_lineFeatureLayer->clearSelection();
 
       m_busy = true;
-      emit isBusy();
+      emit busyStateChanged();
 
       updateMessage("Identifying feature to edit...");
 
@@ -245,7 +245,7 @@ void ValidateUtilityNetworkTopology::onIdentifyLayersAsyncCompleted(const QList<
     updateMessage("No feature identified. Tap on a feature to edit.");
 
     m_busy = false;
-    emit isBusy();
+    emit busyStateChanged();
 
     return;
   }
@@ -284,15 +284,15 @@ void ValidateUtilityNetworkTopology::onIdentifyLayersAsyncCompleted(const QList<
   updateMessage("Select a new " + m_updateFieldName);
 
   m_isClearBtnEnabled = true;
-  emit isClearBtnEnabled();
+  emit clearBtnStateChanged();
 
   m_isUpdateWindowVisible = true;
-  emit isUpdateWindowVisible();
+  emit updateWindowVisibilityChanged();
 
   m_busy = false;
-  emit isBusy();
+  emit busyStateChanged();
 
-  emit updateFieldName();
+  emit fieldNameChanged();
 }
 
 void ValidateUtilityNetworkTopology::onApplyEdits(const QString& choice)
@@ -302,7 +302,7 @@ void ValidateUtilityNetworkTopology::onApplyEdits(const QString& choice)
   m_serviceGeodatabase = static_cast<ServiceFeatureTable*>(m_featureToEdit->featureTable())->serviceGeodatabase();
 
   m_busy = true;
-  emit isBusy();
+  emit busyStateChanged();
 
   for (const CodedValue &codedValue : m_codedValues)
   {
@@ -338,13 +338,13 @@ void ValidateUtilityNetworkTopology::onApplyEdits(const QString& choice)
       }
 
       m_busy = false;
-      emit isBusy();
+      emit busyStateChanged();
     }).onFailed(this, [this]()
     {
       updateMessage("Apply edits failed.");
 
       m_busy = false;
-      emit isBusy();
+      emit busyStateChanged();
     });
   });
 
@@ -352,13 +352,13 @@ void ValidateUtilityNetworkTopology::onApplyEdits(const QString& choice)
   m_lineFeatureLayer->clearSelection();
 
   m_isUpdateWindowVisible = false;
-  emit isUpdateWindowVisible();
+  emit updateWindowVisibilityChanged();
 
   m_isValidateBtnEnabled = true;
-  emit isValidateBtnEnabled();
+  emit validateBtnStateChanged();
 
   m_isClearBtnEnabled = false;
-  emit isClearBtnEnabled();
+  emit clearBtnStateChanged();
 }
 
 void ValidateUtilityNetworkTopology::onClear()
@@ -368,14 +368,14 @@ void ValidateUtilityNetworkTopology::onClear()
   m_lineFeatureLayer->clearSelection();
 
   m_isUpdateWindowVisible = false;
-  emit isUpdateWindowVisible();
+  emit updateWindowVisibilityChanged();
 
   m_featureToEdit = nullptr;
 
   updateMessage("Selection cleared.");
 
   m_isClearBtnEnabled = false;
-  emit isClearBtnEnabled();
+  emit clearBtnStateChanged();
 }
 
 void ValidateUtilityNetworkTopology::onGetState()
@@ -385,7 +385,7 @@ void ValidateUtilityNetworkTopology::onGetState()
   if (m_utilityNetwork && m_utilityNetwork->definition()->capabilities()->isSupportsNetworkState())
   {
     m_busy = true;
-    emit isBusy();
+    emit busyStateChanged();
 
     updateMessage("Getting utility network state...");
 
@@ -395,11 +395,11 @@ void ValidateUtilityNetworkTopology::onGetState()
 
       // Validate if dirty areas or errors exist
       m_isValidateBtnEnabled = m_utilityNetworkstate->hasDirtyAreas();
-      emit isValidateBtnEnabled();
+      emit validateBtnStateChanged();
 
       // Trace if network topology is enabled
       m_isTraceBtnEnabled = m_utilityNetworkstate->isNetworkTopologyEnabled();
-      emit isTraceBtnEnabled();
+      emit traceBtnStateChanged();
 
       m_message = QString("Utility Network State:\n"
           "    Has Dirty Areas: " + QString(m_utilityNetworkstate && m_utilityNetworkstate->hasDirtyAreas() ? "true" : "false") + "\n"
@@ -420,7 +420,7 @@ void ValidateUtilityNetworkTopology::onGetState()
       m_utilityNetworkstate->deleteLater();
 
       m_busy = false;
-      emit isBusy();
+      emit busyStateChanged();
     });
   }
 }
@@ -435,7 +435,7 @@ void ValidateUtilityNetworkTopology::onValidate()
     const Envelope extent = m_mapView->currentViewpoint(ViewpointType::BoundingGeometry).targetGeometry().extent();
 
     m_busy = true;
-    emit isBusy();
+    emit busyStateChanged();
 
     updateMessage("Validating utility network topology...");
 
@@ -456,10 +456,10 @@ void ValidateUtilityNetworkTopology::onValidate()
             "    Click 'Get State' to check the updated network state.");
 
         m_isValidateBtnEnabled = result->hasDirtyAreas();
-        emit isValidateBtnEnabled();
+        emit validateBtnStateChanged();
 
         m_busy = false;
-        emit isBusy();
+        emit busyStateChanged();
 
         job->deleteLater();
       }
@@ -468,7 +468,7 @@ void ValidateUtilityNetworkTopology::onValidate()
         updateMessage("Validate network topology failed.");
 
         m_busy = false;
-        emit isBusy();
+        emit busyStateChanged();
 
         job->deleteLater();
       }
@@ -477,7 +477,7 @@ void ValidateUtilityNetworkTopology::onValidate()
         updateMessage("Validate network topology cancelled.");
 
         m_busy = false;
-        emit isBusy();
+        emit busyStateChanged();
 
         job->deleteLater();
       }
@@ -495,7 +495,7 @@ void ValidateUtilityNetworkTopology::onTrace()
     updateMessage("Running a downstream trace...");
 
     m_busy = true;
-    emit isBusy();
+    emit busyStateChanged();
 
     // Clear previous selection from the layers.
     m_deviceFeatureLayer->clearSelection();
@@ -505,7 +505,7 @@ void ValidateUtilityNetworkTopology::onTrace()
     m_utilityNetwork->traceAsync(m_traceParameters).then(this, [this](QList<UtilityTraceResult*>)
     {
       m_busy = false;
-      emit isBusy();
+      emit busyStateChanged();
 
       UtilityTraceResult* result = m_utilityNetwork->traceResult()->at(0);
 
@@ -537,7 +537,7 @@ void ValidateUtilityNetworkTopology::onTrace()
         std::unique_ptr<FeatureQueryResult> {rawResult};
 
         m_isClearBtnEnabled = true;
-        emit isClearBtnEnabled();
+        emit clearBtnStateChanged();
       });
       result->deleteLater();
     }).onFailed(this, [this]()
@@ -546,7 +546,7 @@ void ValidateUtilityNetworkTopology::onTrace()
           "Click 'Get State' to check the updated network state.");
 
       m_busy = false;
-      emit isBusy();
+      emit busyStateChanged();
     });
   }
 }
@@ -641,13 +641,13 @@ void ValidateUtilityNetworkTopology::setupTraceParameters()
   m_traceParameters->setTraceConfiguration(m_traceConfiguration);
 
   m_isValidateBtnEnabled = m_utilityNetwork->definition()->capabilities()->isSupportsValidateNetworkTopology();
-  emit isValidateBtnEnabled();
+  emit validateBtnStateChanged();
   m_isTraceBtnEnabled = m_utilityNetwork->definition()->capabilities()->isSupportsTrace();
-  emit isTraceBtnEnabled();
+  emit traceBtnStateChanged();
   m_isStateBtnEnabled = m_utilityNetwork->definition()->capabilities()->isSupportsNetworkState();
-  emit isStateBtnEnabled();
+  emit stateBtnStateChanged();
   m_isClearBtnEnabled = false;
-  emit isClearBtnEnabled();
+  emit clearBtnStateChanged();
 
   updateMessage("Utility Network Loaded\n"
       "Tap on a feature to edit.\n"
@@ -656,7 +656,7 @@ void ValidateUtilityNetworkTopology::setupTraceParameters()
       "Click 'Trace' to run a trace.");
 
   m_busy = false;
-  emit isBusy();
+  emit busyStateChanged();
 }
 
 LabelDefinition* ValidateUtilityNetworkTopology::createDeviceLabelDefinition()

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.h
@@ -107,7 +107,7 @@ private:
   QString m_fieldName;
   QList<QString> m_choices;
   bool m_updateWindowVisibility = false;
-  bool m_validateButtonAvailability = false;;
+  bool m_validateButtonAvailability = false;
   bool m_traceButtonAvailability = false;
   bool m_progressBarVisibility = false;
   bool m_clearButtonAvailability = false;

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.h
@@ -46,13 +46,13 @@ class ValidateUtilityNetworkTopology : public QObject
   Q_PROPERTY(Esri::ArcGISRuntime::MapQuickView* mapView READ mapView WRITE setMapView NOTIFY mapViewChanged)
   Q_PROPERTY(QString message MEMBER m_message NOTIFY messageChanged)
   Q_PROPERTY(QList<QString> choices MEMBER m_choices NOTIFY choicesChanged)
-  Q_PROPERTY(bool isUpdateWindowVisible MEMBER m_isUpdateWindowVisible NOTIFY updateWindowVisibilityChanged)
-  Q_PROPERTY(QString updateFieldName MEMBER m_updateFieldName NOTIFY fieldNameChanged)
-  Q_PROPERTY(bool isValidateBtnEnabled MEMBER m_isValidateBtnEnabled NOTIFY validateBtnStateChanged)
-  Q_PROPERTY(bool isTraceBtnEnabled MEMBER m_isTraceBtnEnabled NOTIFY traceBtnStateChanged)
-  Q_PROPERTY(bool isClearBtnEnabled MEMBER m_isClearBtnEnabled NOTIFY clearBtnStateChanged)
-  Q_PROPERTY(bool busy MEMBER m_busy NOTIFY busyStateChanged)
-  Q_PROPERTY(bool isStateBtnEnabled MEMBER m_isStateBtnEnabled NOTIFY stateBtnStateChanged)
+  Q_PROPERTY(bool updateWindowVisibility MEMBER m_updateWindowVisibility NOTIFY updateWindowVisibilityChanged)
+  Q_PROPERTY(QString fieldName MEMBER m_fieldName NOTIFY fieldNameChanged)
+  Q_PROPERTY(bool validateButtonAvailability MEMBER m_validateButtonAvailability NOTIFY validateButtonAvailabilityChanged)
+  Q_PROPERTY(bool traceButtonAvailability MEMBER m_traceButtonAvailability NOTIFY traceButtonAvailabilityChanged)
+  Q_PROPERTY(bool clearButtonAvailability MEMBER m_clearButtonAvailability NOTIFY clearButtonAvailabilityChanged)
+  Q_PROPERTY(bool progressBarVisibility MEMBER m_progressBarVisibility NOTIFY progressBarVisibilityChanged)
+  Q_PROPERTY(bool stateButtonAvailability MEMBER m_stateButtonAvailability NOTIFY stateButtonAvailabilityChanged)
 
 public:
   explicit ValidateUtilityNetworkTopology(QObject* parent = nullptr);
@@ -71,11 +71,11 @@ signals:
   void choicesChanged();
   void updateWindowVisibilityChanged();
   void fieldNameChanged();
-  void validateBtnStateChanged();
-  void traceBtnStateChanged();
-  void busyStateChanged();
-  void clearBtnStateChanged();
-  void stateBtnStateChanged();
+  void validateButtonAvailabilityChanged();
+  void traceButtonAvailabilityChanged();
+  void progressBarVisibilityChanged();
+  void clearButtonAvailabilityChanged();
+  void stateButtonAvailabilityChanged();
 
 private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;
@@ -104,14 +104,14 @@ private:
   Esri::ArcGISRuntime::FeatureLayer* m_lineFeatureLayer = nullptr;
   Esri::ArcGISRuntime::ServiceGeodatabase* m_serviceGeodatabase = nullptr;
   QString m_message;
-  QString m_updateFieldName;
+  QString m_fieldName;
   QList<QString> m_choices;
-  bool m_isUpdateWindowVisible = false;
-  bool m_isValidateBtnEnabled = false;;
-  bool m_isTraceBtnEnabled = false;
-  bool m_busy = false;
-  bool m_isClearBtnEnabled = false;
-  bool m_isStateBtnEnabled = false;
+  bool m_updateWindowVisibility = false;
+  bool m_validateButtonAvailability = false;;
+  bool m_traceButtonAvailability = false;
+  bool m_progressBarVisibility = false;
+  bool m_clearButtonAvailability = false;
+  bool m_stateButtonAvailability = false;
 };
 
 #endif // VALIDATEUTILITYNETWORKTOPOLOGY_H

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.h
@@ -46,13 +46,13 @@ class ValidateUtilityNetworkTopology : public QObject
   Q_PROPERTY(Esri::ArcGISRuntime::MapQuickView* mapView READ mapView WRITE setMapView NOTIFY mapViewChanged)
   Q_PROPERTY(QString message MEMBER m_message NOTIFY messageChanged)
   Q_PROPERTY(QList<QString> choices MEMBER m_choices NOTIFY choicesChanged)
-  Q_PROPERTY(bool isUpdateWindowVisible MEMBER m_isUpdateWindowVisible NOTIFY isUpdateWindowVisible)
-  Q_PROPERTY(QString updateFieldName MEMBER m_updateFieldName NOTIFY updateFieldName)
-  Q_PROPERTY(bool isValidateBtnEnabled MEMBER m_isValidateBtnEnabled NOTIFY isValidateBtnEnabled)
-  Q_PROPERTY(bool isTraceBtnEnabled MEMBER m_isTraceBtnEnabled NOTIFY isTraceBtnEnabled)
-  Q_PROPERTY(bool isClearBtnEnabled MEMBER m_isClearBtnEnabled NOTIFY isClearBtnEnabled)
-  Q_PROPERTY(bool busy MEMBER m_busy NOTIFY isBusy)
-  Q_PROPERTY(bool isStateBtnEnabled MEMBER m_isStateBtnEnabled NOTIFY isStateBtnEnabled)
+  Q_PROPERTY(bool isUpdateWindowVisible MEMBER m_isUpdateWindowVisible NOTIFY updateWindowVisibilityChanged)
+  Q_PROPERTY(QString updateFieldName MEMBER m_updateFieldName NOTIFY fieldNameChanged)
+  Q_PROPERTY(bool isValidateBtnEnabled MEMBER m_isValidateBtnEnabled NOTIFY validateBtnStateChanged)
+  Q_PROPERTY(bool isTraceBtnEnabled MEMBER m_isTraceBtnEnabled NOTIFY traceBtnStateChanged)
+  Q_PROPERTY(bool isClearBtnEnabled MEMBER m_isClearBtnEnabled NOTIFY clearBtnStateChanged)
+  Q_PROPERTY(bool busy MEMBER m_busy NOTIFY busyStateChanged)
+  Q_PROPERTY(bool isStateBtnEnabled MEMBER m_isStateBtnEnabled NOTIFY stateBtnStateChanged)
 
 public:
   explicit ValidateUtilityNetworkTopology(QObject* parent = nullptr);
@@ -69,13 +69,13 @@ signals:
   void mapViewChanged();
   void messageChanged();
   void choicesChanged();
-  void isUpdateWindowVisible();
-  void updateFieldName();
-  void isValidateBtnEnabled();
-  void isTraceBtnEnabled();
-  void isBusy();
-  void isClearBtnEnabled();
-  void isStateBtnEnabled();
+  void updateWindowVisibilityChanged();
+  void fieldNameChanged();
+  void validateBtnStateChanged();
+  void traceBtnStateChanged();
+  void busyStateChanged();
+  void clearBtnStateChanged();
+  void stateBtnStateChanged();
 
 private:
   Esri::ArcGISRuntime::MapQuickView* mapView() const;

--- a/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.qml
@@ -77,7 +77,7 @@ Item {
                         Layout.fillWidth: true
                         onClicked: model.onGetState()
                         Layout.preferredWidth: clearBtn.width
-                        enabled: model.isStateBtnEnabled
+                        enabled: model.stateButtonAvailability
                     }
                     Button {
                         id: validateBtn
@@ -85,7 +85,7 @@ Item {
                         Layout.row: 0
                         Layout.column: 1
                         Layout.fillWidth: true
-                        enabled: model.isValidateBtnEnabled
+                        enabled: model.validateButtonAvailability
                         onClicked: model.onValidate()
                         Layout.preferredWidth: clearBtn.width
                     }
@@ -95,7 +95,7 @@ Item {
                         Layout.row: 1
                         Layout.column: 0
                         Layout.fillWidth: true
-                        enabled: model.isTraceBtnEnabled
+                        enabled: model.traceButtonAvailability
                         onClicked: model.onTrace()
                         Layout.preferredWidth: clearBtn.width
                     }
@@ -106,7 +106,7 @@ Item {
                         Layout.column: 1
                         Layout.fillWidth: true
                         onClicked: model.onClear()
-                        enabled: model.isClearBtnEnabled
+                        enabled: model.clearButtonAvailability
                     }
                     Text {
                         id: status
@@ -117,7 +117,7 @@ Item {
                     }
                     ProgressBar {
                         id: isBusy
-                        visible: model.busy
+                        visible: model.progressBarVisibility
                         Layout.row: 3
                         Layout.columnSpan: 2
                         Layout.fillWidth: true
@@ -130,7 +130,7 @@ Item {
     Rectangle {
         id: updateWindow
         anchors.centerIn: parent
-        visible: model.isUpdateWindowVisible
+        visible: model.updateWindowVisibility
         enabled: visible
         width: childrenRect.width
         height: childrenRect.height
@@ -148,7 +148,7 @@ Item {
                 columns: 2
                 rows: 2
                 Text {
-                    text: model.updateFieldName
+                    text: model.fieldName
                     Layout.alignment: Qt.AlignRight
                     rightPadding: 20
                 }


### PR DESCRIPTION
# Description

This PR is to change signal names in `Validate Utility Network topology` sample

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

