### PR TITLE
Change for anonymous sign-in to do not challenge

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
@@ -56,7 +56,7 @@ void ShowOrgBasemaps::connectLoadStatusSignal()
 {
   if (m_portal)
   {
-    connect(m_portal.get(), &Portal::loadStatusChanged, this, [this]()
+    connect(m_portal, &Portal::loadStatusChanged, this, [this]()
     {
       m_portalLoaded = m_portal->loadStatus() == LoadStatus::Loaded;
       m_portalLoading = m_portal->loadStatus() == LoadStatus::Loading;
@@ -110,10 +110,14 @@ QString ShowOrgBasemaps::mapLoadError() const
 
 void ShowOrgBasemaps::load(bool anonymous)
 {
-  m_portal.reset(new Portal(this));
+  if (m_portal)
+    delete m_portal;
+
+  m_portal = new Portal(this);
   connectLoadStatusSignal();
 
-  if (!anonymous && m_portal) {
+  if (!anonymous && m_portal)
+  {
     Credential* cred = new Credential(OAuthClientInfo("iLkGIj0nX8A4EJda", OAuthMode::User), this);
     m_portal->setCredential(cred);
   }

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
@@ -111,7 +111,10 @@ QString ShowOrgBasemaps::mapLoadError() const
 void ShowOrgBasemaps::load(bool anonymous)
 {
   if (m_portal)
+  {
     delete m_portal;
+    m_portal = nullptr;
+  }
 
   m_portal = new Portal(this);
   connectLoadStatusSignal();

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
@@ -42,7 +42,6 @@ public:
   explicit ShowOrgBasemaps(QQuickItem* parent = nullptr);
   ~ShowOrgBasemaps() override;
 
-  void componentComplete() override;
   static void init();
 
   bool portalLoaded() const;
@@ -64,10 +63,11 @@ signals:
 
 private:
   void load();
+  void connectLoadStatusSignal();
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
-  Esri::ArcGISRuntime::Portal* m_portal = nullptr;
+  std::shared_ptr<Esri::ArcGISRuntime::Portal> m_portal = nullptr;
   bool m_portalLoaded = false;
   bool m_portalLoading = false;
   QString m_mapLoadError;

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.h
@@ -67,7 +67,7 @@ private:
 
   Esri::ArcGISRuntime::Map* m_map = nullptr;
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
-  std::shared_ptr<Esri::ArcGISRuntime::Portal> m_portal = nullptr;
+  Esri::ArcGISRuntime::Portal* m_portal = nullptr;
   bool m_portalLoaded = false;
   bool m_portalLoading = false;
   QString m_mapLoadError;

--- a/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
+++ b/ArcGISRuntimeSDKQt_CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.qml
@@ -220,7 +220,6 @@ ShowOrgBasemapsSample {
 
         onClicked: {
             load(false);
-            anonymousLogIn.enabled = false;
         }
     }
 


### PR DESCRIPTION
# Description

Issue: When we first try to `sign in`, then close it and then we try `anonymous` sign-in it will challenge you.

Fix: reset the portal so that the anonymous sign-in do not challenge in above scenario. 

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
