### PR TITLE
Jare8800/fix clusters

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.cpp
@@ -240,9 +240,6 @@ void ConfigureClusters::mouseClicked(QMouseEvent& mouseEvent)
   // Identify the tapped observation.
   m_mapView->identifyLayerAsync(m_layer, mouseEvent.position(), 3.0, true, m_resultParent.get()).then(this, [this](IdentifyLayerResult* result)
   {
-    // clear the list of popup content
-    m_popupContent.clear();
-
     // clear cluster selection
     if (m_aggregateGeoElement)
       m_aggregateGeoElement->setSelected(false);

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.cpp
@@ -227,21 +227,31 @@ void ConfigureClusters::mouseClicked(QMouseEvent& mouseEvent)
   if (!m_layer)
     return;
 
+  m_popupContent.clear();
+
+  // clear cluster selection
+  if (m_aggregateGeoElement)
+    m_aggregateGeoElement->setSelected(false);
+
+  // Clean up any children objects associated with this parent
+  m_resultParent.reset(new QObject(this));
+  m_aggregateGeoElement = nullptr;
+
   // Identify the tapped observation.
-  m_mapView->identifyLayerAsync(m_layer, mouseEvent.position(), 3.0, true).then(this, [this](IdentifyLayerResult* result)
+  m_mapView->identifyLayerAsync(m_layer, mouseEvent.position(), 3.0, true, m_resultParent.get()).then(this, [this](IdentifyLayerResult* result)
   {
     // clear the list of popup content
     m_popupContent.clear();
 
     // clear cluster selection
-    if (m_aggregateGeoElement.get())
+    if (m_aggregateGeoElement)
       m_aggregateGeoElement->setSelected(false);
 
     for (Popup* popup: result->popups())
     {
       // if the identified object is a cluster, select it
-      m_aggregateGeoElement.reset(dynamic_cast<AggregateGeoElement*>(popup->geoElement()));
-      if (m_aggregateGeoElement.get())
+      m_aggregateGeoElement = dynamic_cast<AggregateGeoElement*>(popup->geoElement());
+      if (m_aggregateGeoElement)
         m_aggregateGeoElement->setSelected(true);
 
       const auto attributes = popup->geoElement()->attributes();

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.cpp
@@ -227,6 +227,7 @@ void ConfigureClusters::mouseClicked(QMouseEvent& mouseEvent)
   if (!m_layer)
     return;
 
+  // clear the list of popup content
   m_popupContent.clear();
 
   // clear cluster selection

--- a/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Layers/ConfigureClusters/ConfigureClusters.h
@@ -72,8 +72,10 @@ private:
   Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
   Esri::ArcGISRuntime::FeatureLayer* m_layer = nullptr;
   Esri::ArcGISRuntime::ClusteringFeatureReduction* m_clusteringFeatureReduction = nullptr;
-  QScopedPointer<Esri::ArcGISRuntime::AggregateGeoElement> m_aggregateGeoElement;
   QString m_popupContent;
+
+  QScopedPointer<QObject> m_resultParent;
+  Esri::ArcGISRuntime::AggregateGeoElement* m_aggregateGeoElement = nullptr;
 };
 
 #endif // ConfigureClusters_H


### PR DESCRIPTION
# Description

Parent relationship was wrong so when the sample closed the object was getting cleaned up twice. 

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
