### PR TITLE
QFuturize EditFeatureAttachments and Geotriggers sample

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -229,22 +229,20 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
 
   emit displayInfoChanged();
 
-  AttachmentListModel* featureAttachments = feature->attachments();
+  feature->attachments(false, false)->fetchAttachmentsAsync().then(
+      [this, sectionName](const QList<Attachment*>& attachments)
+      {
+        if (attachments.isEmpty())
+          return;
 
-  // Fetch attachments will automatically trigger upon instantiation of the AttachmentListModel
-  connect(featureAttachments, &AttachmentListModel::fetchAttachmentsCompleted, this, [this, sectionName](const QUuid&, const QList<Attachment*>& attachments)
-  {
-    if (attachments.isEmpty())
-      return;
+        // Get the first (and only) attachment for the feature
+        Attachment* sectionImageAttachment = attachments.first();
 
-    // Get the first (and only) attachment for the feature
-    Attachment* sectionImageAttachment = attachments.first();
-
-    sectionImageAttachment->fetchDataAsync().then(this, [this, sectionImageAttachment, sectionName](const QByteArray&)
-    {
-      m_featureAttachmentImageUrls[sectionName] = sectionImageAttachment->attachmentUrl();
-      m_currentFeatureImageUrl = m_featureAttachmentImageUrls[sectionName];
-      emit displayInfoChanged();
-    });
-  });
+        sectionImageAttachment->fetchDataAsync().then(this, [this, sectionImageAttachment, sectionName](const QByteArray&)
+        {
+          m_featureAttachmentImageUrls[sectionName] = sectionImageAttachment->attachmentUrl();
+          m_currentFeatureImageUrl = m_featureAttachmentImageUrls[sectionName];
+          emit displayInfoChanged();
+        });
+      });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -228,8 +228,10 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
   }
 
   emit displayInfoChanged();
-
-  feature->attachments(false, false)->fetchAttachmentsAsync().then(
+  // enableAutoFetch and enableAutoApplyEdits for AttachmentListModel are set as false
+  // to avoid automatic behavior. We will call fetchDataAsync explicitly as needed.
+  m_attachmentListModel = feature->attachments(false, false);
+  m_attachmentListModel->fetchAttachmentsAsync().then(
       [this, sectionName](const QList<Attachment*>& attachments)
       {
         if (attachments.isEmpty())
@@ -245,4 +247,7 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
           emit displayInfoChanged();
         });
       });
+
+ auto future = m_gardenSections->applyEditsAsync(this);
+ Q_UNUSED(future)
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -27,6 +27,7 @@
 #include "GeotriggerNotificationInfo.h"
 #include "GeotriggerMonitor.h"
 #include "GeotriggersTypes.h"
+#include "FeatureEditResult.h"
 #include "FeatureFenceParameters.h"
 #include "LocationGeotriggerFeed.h"
 #include "LocationDisplay.h"
@@ -244,9 +245,10 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
           m_featureAttachmentImageUrls[sectionName] = sectionImageAttachment->attachmentUrl();
           m_currentFeatureImageUrl = m_featureAttachmentImageUrls[sectionName];
           emit displayInfoChanged();
-        });
-        qDeleteAll(attachments);
+        }); 
       });
-   auto future = m_gardenSections->applyEditsAsync(this);
-   Q_UNUSED(future)
+  m_gardenSections->applyEditsAsync(this).then(this, [](QList<FeatureEditResult*> results)
+  {
+    qDeleteAll(results);
+  });
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -230,8 +230,7 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
   emit displayInfoChanged();
   // enableAutoFetch and enableAutoApplyEdits for AttachmentListModel are set as false
   // to avoid automatic behavior. We will call fetchDataAsync explicitly as needed.
-  m_attachmentListModel = feature->attachments(false, false);
-  m_attachmentListModel->fetchAttachmentsAsync().then(
+  feature->attachments(false, false)->fetchAttachmentsAsync().then(
       [this, sectionName](const QList<Attachment*>& attachments)
       {
         if (attachments.isEmpty())

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -245,8 +245,8 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
           m_currentFeatureImageUrl = m_featureAttachmentImageUrls[sectionName];
           emit displayInfoChanged();
         });
+        qDeleteAll(attachments);
       });
-
- auto future = m_gardenSections->applyEditsAsync(this);
- Q_UNUSED(future)
+   auto future = m_gardenSections->applyEditsAsync(this);
+   Q_UNUSED(future)
 }

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.h
@@ -20,7 +20,6 @@
 namespace Esri::ArcGISRuntime
 {
 class ArcGISFeature;
-class AttachmentListModel;
 class GeotriggerFeed;
 class GeotriggerMonitor;
 class GeotriggerNotificationInfo;
@@ -85,8 +84,6 @@ private:
   QUrl m_currentFeatureImageUrl;
   QMap<QString, Esri::ArcGISRuntime::ArcGISFeature*> m_featureQMap;
   QMap<QString, QUrl> m_featureAttachmentImageUrls;
-  Esri::ArcGISRuntime::AttachmentListModel* m_attachmentListModel = nullptr;
-
 };
 
 #endif // GEOTRIGGERS_H

--- a/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/Analysis/Geotriggers/Geotriggers.h
@@ -85,6 +85,7 @@ private:
   QUrl m_currentFeatureImageUrl;
   QMap<QString, Esri::ArcGISRuntime::ArcGISFeature*> m_featureQMap;
   QMap<QString, QUrl> m_featureAttachmentImageUrls;
+  Esri::ArcGISRuntime::AttachmentListModel* m_attachmentListModel = nullptr;
 
 };
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -237,7 +237,7 @@ void EditFeatureAttachments::onQueryFeaturesCompleted_(FeatureQueryResult* featu
     emit attachmentModelChanged();
 
     // get the number of attachments
-    // enableAutoFetch and enableAutoApplyEdits arguments of attachments() is set as false to avoid auto-fetching and auto-apply edits.
+    // enableAutoFetch and enableAutoApplyEdits for AttachmentListModel are set as false to avoid automatic behavior. We will call fetchDataAsync explicitly as needed.
     m_selectedFeature->attachments(false, false)->fetchAttachmentsAsync().then(
         [this](const QList<Attachment*>& attachments)
         {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -236,13 +236,12 @@ void EditFeatureAttachments::onQueryFeaturesCompleted_(FeatureQueryResult* featu
     emit featureSelected();
     emit attachmentModelChanged();
 
-    // get the number of attachments
-    connect(m_selectedFeature->attachments(), &AttachmentListModel::fetchAttachmentsCompleted,
-            this, [this](const QUuid&, const QList<Attachment*>& attachments)
-    {
-      m_mapView->calloutData()->setDetail(QString("Number of attachments: %1").arg(attachments.size()));
-      m_mapView->calloutData()->setVisible(true); // Resizes the calloutData after details has been set.
-    });
+    m_selectedFeature->attachments(false, false)->fetchAttachmentsAsync().then(
+        [this](const QList<Attachment*>& attachments)
+        {
+          m_mapView->calloutData()->setDetail(QString("Number of attachments: %1").arg(attachments.size()));
+          m_mapView->calloutData()->setVisible(true); // Resizes the calloutData after details has been set.
+        });
   }
 }
 

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -18,7 +18,6 @@
 #include "pch.hpp"
 #endif // PCH_BUILD
 
-#include "AttachmentListModel.h"
 #include "EditFeatureAttachments.h"
 
 #include "Map.h"

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -236,6 +236,8 @@ void EditFeatureAttachments::onQueryFeaturesCompleted_(FeatureQueryResult* featu
     emit featureSelected();
     emit attachmentModelChanged();
 
+    // get the number of attachments
+    // enableAutoFetch and enableAutoApplyEdits arguments of attachments() is set as false to avoid auto-fetching and auto-apply edits.
     m_selectedFeature->attachments(false, false)->fetchAttachmentsAsync().then(
         [this](const QList<Attachment*>& attachments)
         {

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
@@ -19,6 +19,7 @@
 
 namespace Esri::ArcGISRuntime
 {
+  class AttachmentListModel;
   class CalloutData;
   class Map;
   class MapQuickView;
@@ -59,6 +60,7 @@ signals:
 private:
   void connectSignals();
   QAbstractListModel* attachmentModel() const;
+  void applyEdits();
 
   void onIdentifyLayerCompleted_(Esri::ArcGISRuntime::IdentifyLayerResult* identifyResult);
   void onQueryFeaturesCompleted_(Esri::ArcGISRuntime::FeatureQueryResult* featureQueryResult);
@@ -69,6 +71,7 @@ private:
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
   Esri::ArcGISRuntime::ServiceFeatureTable* m_featureTable = nullptr;
   Esri::ArcGISRuntime::ArcGISFeature* m_selectedFeature = nullptr;
+  Esri::ArcGISRuntime::AttachmentListModel* m_attachmentListModel = nullptr;
   QString m_whereClause;
   QMetaObject::Connection m_attachmentConnection;
 };

--- a/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
+++ b/ArcGISRuntimeSDKQt_CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.h
@@ -19,7 +19,6 @@
 
 namespace Esri::ArcGISRuntime
 {
-  class AttachmentListModel;
   class CalloutData;
   class Map;
   class MapQuickView;
@@ -71,7 +70,6 @@ private:
   Esri::ArcGISRuntime::FeatureLayer* m_featureLayer = nullptr;
   Esri::ArcGISRuntime::ServiceFeatureTable* m_featureTable = nullptr;
   Esri::ArcGISRuntime::ArcGISFeature* m_selectedFeature = nullptr;
-  Esri::ArcGISRuntime::AttachmentListModel* m_attachmentListModel = nullptr;
   QString m_whereClause;
   QMetaObject::Connection m_attachmentConnection;
 };


### PR DESCRIPTION
# Description

QFuturized EditFeatureAttachments and Geotriggers samples.

Yet to do some more testing to confirm no crash.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [x] Self-review of changes
- [ ] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
