### PR TITLE
Let the implicit sizing handle displaying the button.

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_Samples/qml/SourceCodeView.qml
@@ -47,12 +47,7 @@ Rectangle {
 
             Menu {
                 id: contextMenu
-                width: 72
-                height: 36
-
                 MenuItem {
-                    width: contextMenu.width - 10
-                    height: contextMenu.height - 10
                     text: qsTr('Copy')
                     onTriggered: {
                         textEdit.copy()


### PR DESCRIPTION
# Description

Remove the explicit size params on the `copy` menu item. Verified on macOS, but am unsure if highlighting code and displaying the `copy` dialog is supported on mobile?

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
