### PR TITLE
Fix url in 3D Tiles layer (main)

### DIFF
--- a/ArcGISRuntimeSDKQt_CppSamples/Scenes/Add3DTilesLayer/Add3DTilesLayer.cpp
+++ b/ArcGISRuntimeSDKQt_CppSamples/Scenes/Add3DTilesLayer/Add3DTilesLayer.cpp
@@ -78,7 +78,7 @@ void Add3DTilesLayer::setSceneView(SceneQuickView* sceneView)
 
 void Add3DTilesLayer::add3DTilesLayer()
 {
-  const QUrl modelPath = QUrl("https://tiles.arcgis.com/tiles/N82JbI5EYtAkuUKU/arcgis/rest/services/Stuttgart/3DTilesServer/tileset.json");
+  const QUrl modelPath = QUrl("https://tiles.arcgis.com/tiles/ZQgQTuoyBrtmoGdP/arcgis/rest/services/Stuttgart/3DTilesServer/tileset.json");
   m_ogc3dTilesLayer = new Ogc3dTilesLayer(modelPath, this);
   m_scene->operationalLayers()->append(m_ogc3dTilesLayer);
 }


### PR DESCRIPTION
# Description

`Main` mirror of https://github.com/Esri/arcgis-maps-sdk-samples-qt/pull/1711 that was merged into `v.next`.
Updates a source URL.

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] macOS