### PR TITLE
Add BasemapStyleListModel to qrc

### DIFF
--- a/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.qrc
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.qrc
@@ -8,5 +8,7 @@
         <file>screenshot.png</file>
         <file>README.md</file>
         <file>grid-24.svg</file>
+        <file>BasemapStyleListModel.cpp</file>
+        <file>BasemapStyleListModel.h</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
# Description

This PR adds `BasemapStyleListModel.h` and `BasemapStyleListModel.cpp` to `CreateDynamicBasemapGallery.qrc` to ensure the code appears in the `Source Code` section of the sample viewer.

The change has been tested locally by building and running the sample viewer and ensuring the code for the `BasemapStyleListModel` class is visible in the `Source Code` section of the `CreateDynamicBasemapGallery` sample.

## Type of change

- [x] Bug fix
