### PR TITLE
Update for LoadableImage disk path

### DIFF
--- a/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
@@ -59,13 +59,13 @@ void BasemapStyleListModel::insertItemsIntoGallery(const QList<BasemapStyleInfo*
 {
     beginResetModel();
     m_previews.clear();
-    for (const BasemapStyleInfo* info : infos)
+    for (auto index = 0; index < infos.size(); ++index)
     {
-        connect(info, &BasemapStyleInfo::thumbnailUrlChanged, this, [this, info]() {
-            QModelIndex index = createIndex(m_previews.indexOf(info), 0);
-            emit dataChanged(index, index);
+        m_previews.insert(index, std::move(infos.at(index)));
+        QModelIndex modelIndex = createIndex(index, 0);
+        connect(m_previews.at(index), &BasemapStyleInfo::thumbnailUrlChanged, this, [this, modelIndex]() {
+            emit dataChanged(modelIndex, modelIndex);
         });
-        m_previews.append(info);
     }
     endResetModel();
 }

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
@@ -62,8 +62,9 @@ void BasemapStyleListModel::insertItemsIntoGallery(const QList<BasemapStyleInfo*
     for (auto index = 0; index < infos.size(); ++index)
     {
         m_previews.insert(index, infos.at(index));
-        QModelIndex modelIndex = createIndex(index, 0);
-        connect(m_previews.at(index), &BasemapStyleInfo::thumbnailUrlChanged, this, [this, modelIndex]() {
+        connect(m_previews.at(index), &BasemapStyleInfo::thumbnailUrlChanged, this, [this, index]() 
+        {
+            const QModelIndex modelIndex = createIndex(index, 0);
             emit dataChanged(modelIndex, modelIndex);
         });
     }

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
@@ -64,7 +64,7 @@ void BasemapStyleListModel::insertItemsIntoGallery(const QList<BasemapStyleInfo*
         m_previews.insert(index, infos.at(index));
         connect(m_previews.at(index), &BasemapStyleInfo::thumbnailUrlChanged, this, [this, index]() 
         {
-            const QModelIndex modelIndex = createIndex(index, 0);
+            QModelIndex modelIndex = createIndex(index, 0);
             emit dataChanged(modelIndex, modelIndex);
         });
     }

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
@@ -51,7 +51,7 @@ QVariant BasemapStyleListModel::data(const QModelIndex& index, int role) const
 
 int BasemapStyleListModel::rowCount(const QModelIndex& parent) const
 {
-    Q_UNUSED(parent);
+    Q_UNUSED(parent)
     return m_previews.size();
 }
 

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
@@ -61,7 +61,7 @@ void BasemapStyleListModel::insertItemsIntoGallery(const QList<BasemapStyleInfo*
     m_previews.clear();
     for (auto index = 0; index < infos.size(); ++index)
     {
-        m_previews.insert(index, std::move(infos.at(index)));
+        m_previews.insert(index, infos.at(index));
         QModelIndex modelIndex = createIndex(index, 0);
         connect(m_previews.at(index), &BasemapStyleInfo::thumbnailUrlChanged, this, [this, modelIndex]() {
             emit dataChanged(modelIndex, modelIndex);

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/BasemapStyleListModel.cpp
@@ -51,6 +51,7 @@ QVariant BasemapStyleListModel::data(const QModelIndex& index, int role) const
 
 int BasemapStyleListModel::rowCount(const QModelIndex& parent) const
 {
+    Q_UNUSED(parent);
     return m_previews.size();
 }
 
@@ -60,7 +61,11 @@ void BasemapStyleListModel::insertItemsIntoGallery(const QList<BasemapStyleInfo*
     m_previews.clear();
     for (const BasemapStyleInfo* info : infos)
     {
-        m_previews.append(std::move(info));
+        connect(info, &BasemapStyleInfo::thumbnailUrlChanged, this, [this, info]() {
+            QModelIndex index = createIndex(m_previews.indexOf(info), 0);
+            emit dataChanged(index, index);
+        });
+        m_previews.append(info);
     }
     endResetModel();
 }


### PR DESCRIPTION
# Description

Change is made to update the local url of the image (rather than the portal url) when the image is actually loaded and saved to disk.
The `BasemapStyleInfo::thumbnailUrlChanged()` is emitted when the local path of the image is available.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [x] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
