### PR TITLE
Fix to partial data download issue

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -416,12 +416,12 @@ bool SampleManager::dataItemsExists()
 
   for (auto dataItem : *currentSample()->dataItems())
   {
-    if (dataItem->exists())
+    if (!dataItem->exists())
     {
-      return true;
+      return false;
     }
   }
-  return false;
+  return true;
 }
 
 void SampleManager::downloadAllDataItems()


### PR DESCRIPTION
# Description

This PR is to fix the missing data download option in a sample after partial download elsewhere

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [ ] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
