### PR TITLE
Jared/sample download when offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The repo contains [Qt](http://qt.io) projects for each sample that can be run from within the Qt Creator IDE. It also contians source code to build and run the [C++](https://www.arcgis.com/home/search.html?t=content&q=tags%3A%22CppSampleViewer%22) and [QML](https://www.arcgis.com/home/search.html?t=content&q=tags%3A%22QmlSampleViewer%22) sample viewer apps locally.
+The repo contains [Qt](http://qt.io) projects for each sample that can be run from within the Qt Creator IDE. It also contains source code to build and run the [C++](https://www.arcgis.com/home/search.html?t=content&q=tags%3A%22CppSampleViewer%22) sample viewer app locally.
 
 ## Table of Contents
 
@@ -115,9 +115,9 @@ git merge upstream/main
 
 Start Qt Creator. When the IDE opens to the Welcome screen, click on the **Open Project** button and browse to a project file (.pro) within your forked repo location. Configure the project, [set your ArcGIS Developer API key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/create-and-manage-an-api-key/#set-your-api-key) in `main.cpp`, and run the sample.
 
-## Build and run the ArcGIS Maps SDK for Qt Sample Viewers locally
+## Build and run the ArcGIS Maps SDK for Qt Sample Viewer locally
 
-Start Qt Creator. When the IDE opens to the Welcome screen, click on the **Open Project** button and browse to either sample viewer's project file (.pro) within your forked repo location. The sample viewer project files are located at `arcgis-maps-sdk-samples-qt\ArcGISRuntimeSDKQt_SampleViewers\`, in either `ArcGISRuntimeSDKQt_CppSamples` or `ArcGISRuntimeSDKQt_QMLSamples`. Configure the project, [set your ArcGIS Developer API key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/create-and-manage-an-api-key/#set-your-api-key) in `ArcGISRuntimeSDKQt_Samples\SampleManager.cpp`, and run the sample.
+Start Qt Creator. When the IDE opens to the Welcome screen, click on the **Open Project** button and browse to either sample viewer's project file (.pro) within your forked repo location. The sample viewer project file is located at `arcgis-maps-sdk-samples-qt\SampleViewer\`. Configure the project, [set your ArcGIS Developer API key](https://developers.arcgis.com/documentation/mapping-apis-and-services/security/tutorials/create-and-manage-an-api-key/#set-your-api-key) in `SampleViewer\SampleManager.cpp`, and run the sample.
 
 NOTE: the sample viewer project files search for the toolkit.pri at the [default location specified above](#clone-the-toolkit-repo). If you cloned the toolkit repo to a different location, you will need to update the path in the respective sample viewer's project file.
 

--- a/SampleViewer/qml/DataDownloadView.qml
+++ b/SampleViewer/qml/DataDownloadView.qml
@@ -64,7 +64,7 @@ Page {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             visible: !SampleManager.downloadInProgress
             onClicked: {
-                if (SampleManager.reachability === SampleManager.ReachabilityOnline || SampleManager.reachability === SampleManager.ReachabilityUnknown) {
+                if (SampleManager.reachability === SampleManager.ReachabilityOnline) {
                     SampleManager.downloadDataItemsCurrentSample();
                 } else {
                     SampleManager.currentMode = SampleManager.NetworkRequiredView;

--- a/SampleViewer/qml/ManageOfflineDataView.qml
+++ b/SampleViewer/qml/ManageOfflineDataView.qml
@@ -57,7 +57,7 @@ Page {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             visible: !SampleManager.downloadInProgress
             onClicked: {
-                if (SampleManager.reachability === SampleManager.ReachabilityOnline || SampleManager.reachability === SampleManager.ReachabilityUnknown) {
+                if (SampleManager.reachability === SampleManager.ReachabilityOnline) {
                     SampleManager.downloadAllDataItems();
                 } else {
                     SampleManager.currentMode = SampleManager.NetworkRequiredView;

--- a/SampleViewer/qml/NetworkRequiredView.qml
+++ b/SampleViewer/qml/NetworkRequiredView.qml
@@ -62,7 +62,7 @@ Page {
             height: 48
             text: qsTr("Retry")
             onClicked: {
-                if (SampleManager.reachability === SampleManager.ReachabilityOnline || SampleManager.reachability === SampleManager.ReachabilityUnknown) {
+                if (SampleManager.reachability === SampleManager.ReachabilityOnline) {
                     SampleManager.currentMode = SampleManager.LiveSampleView
                     showSample();
                 }

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -250,8 +250,7 @@ ApplicationWindow {
 
             // If the sample requires online resources but there is no network connectivity
             if (SampleManager.currentSample.dataItems.size === 0
-                    && SampleManager.reachability !== SampleManager.ReachabilityOnline
-                    && SampleManager.reachability !== SampleManager.ReachabilityUnknown){
+                    && SampleManager.reachability !== SampleManager.ReachabilityOnline){
                 SampleManager.currentMode = SampleManager.NetworkRequiredView;
                 return;
             // If the sample requires offline data


### PR DESCRIPTION
# Description

Updated network reachability logic so that the sampleviewer in v.next behaves as it did previously.

Also added in some general doc update that I forgot to do previously.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
