### PR TITLE
Fixing reachability implementation in samples

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -394,7 +394,7 @@ void SampleManager::setApiKey(bool isSupportsApiKey)
 
   if (isSupportsApiKey && apiKey == "")
   {
-    qWarning() << "This sample expects an API key to be set, but none was provided. Please provide an API key in ArcGISRuntimeSDKQt_Samples/SampleManager.cpp";
+    qWarning() << "This sample expects an API key to be set, but none was provided. Please provide an API key in SampleViewer/SampleManager.cpp";
   }
   const QString sampleApiKey = isSupportsApiKey ? apiKey : ""; // empty string will "unset" the key
   // set apikey for CPP/QML sample viewer

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -87,10 +87,10 @@ SampleManager::SampleManager(QObject *parent):
 
   if (QNetworkInformation::loadBackendByFeatures(QNetworkInformation::Feature::Reachability))
   {
-      if (QNetworkInformation* networkInfo = QNetworkInformation::instance())
-      {
-          connect(networkInfo, &QNetworkInformation::reachabilityChanged, this, &SampleManager::reachabilityChanged);
-      }
+    if (QNetworkInformation* networkInfo = QNetworkInformation::instance())
+    {
+      connect(networkInfo, &QNetworkInformation::reachabilityChanged, this, &SampleManager::reachabilityChanged);
+    }
   }
 }
 

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -84,6 +84,14 @@ SampleManager::SampleManager(QObject *parent):
 #ifdef LOCALSERVER_SUPPORTED
   createAndSetTempDirForLocalServer();
 #endif
+
+  if (QNetworkInformation::loadBackendByFeatures(QNetworkInformation::Feature::Reachability))
+  {
+      if (QNetworkInformation* networkInfo = QNetworkInformation::instance())
+      {
+          connect(networkInfo, &QNetworkInformation::reachabilityChanged, this, &SampleManager::reachabilityChanged);
+      }
+  }
 }
 
 SampleManager::~SampleManager() = default;

--- a/SampleViewer/qml/DataDownloadView.qml
+++ b/SampleViewer/qml/DataDownloadView.qml
@@ -64,7 +64,7 @@ Page {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             visible: !SampleManager.downloadInProgress
             onClicked: {
-                if (SampleManager.reachability === SampleManager.ReachabilityOnline) {
+                if (SampleManager.reachability === SampleManager.ReachabilityOnline || SampleManager.reachability === SampleManager.ReachabilityUnknown) {
                     SampleManager.downloadDataItemsCurrentSample();
                 } else {
                     SampleManager.currentMode = SampleManager.NetworkRequiredView;

--- a/SampleViewer/qml/ManageOfflineDataView.qml
+++ b/SampleViewer/qml/ManageOfflineDataView.qml
@@ -57,7 +57,7 @@ Page {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             visible: !SampleManager.downloadInProgress
             onClicked: {
-                if (SampleManager.reachability === SampleManager.ReachabilityOnline) {
+                if (SampleManager.reachability === SampleManager.ReachabilityOnline || SampleManager.reachability === SampleManager.ReachabilityUnknown) {
                     SampleManager.downloadAllDataItems();
                 } else {
                     SampleManager.currentMode = SampleManager.NetworkRequiredView;

--- a/SampleViewer/qml/NetworkRequiredView.qml
+++ b/SampleViewer/qml/NetworkRequiredView.qml
@@ -62,7 +62,7 @@ Page {
             height: 48
             text: qsTr("Retry")
             onClicked: {
-                if (SampleManager.reachability === SampleManager.ReachabilityOnline) {
+                if (SampleManager.reachability === SampleManager.ReachabilityOnline || SampleManager.reachability === SampleManager.ReachabilityUnknown) {
                     SampleManager.currentMode = SampleManager.LiveSampleView
                     showSample();
                 }

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -250,7 +250,8 @@ ApplicationWindow {
 
             // If the sample requires online resources but there is no network connectivity
             if (SampleManager.currentSample.dataItems.size === 0
-                    && SampleManager.reachability !== SampleManager.ReachabilityOnline){
+                    && SampleManager.reachability !== SampleManager.ReachabilityOnline
+                    && SampleManager.reachability !== SampleManager.ReachabilityUnknown){
                 SampleManager.currentMode = SampleManager.NetworkRequiredView;
                 return;
             // If the sample requires offline data


### PR DESCRIPTION
When I ported this over from the plugin, I missed a part which loads the feature `Reachability` to see if it will provide useful information otherwise it will just return unknown which explains the odd logic in our sample viewer now.

Reverted my last changes.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
