### PR TITLE
Fix build number oddities and compiler warning

### DIFF
--- a/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.cpp
@@ -271,7 +271,7 @@ const QStringList& CreateDynamicBasemapGallery::worldviews() const
     return m_worldviews;
 }
 
-const int CreateDynamicBasemapGallery::indexOfSelectedStyle() const
+int CreateDynamicBasemapGallery::indexOfSelectedStyle() const
 {
     return static_cast<int>(m_styleInfos.indexOf(m_selectedStyle));
 }

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.h
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/CreateDynamicBasemapGallery.h
@@ -60,7 +60,7 @@ public:
     const QStringList& languageStrategies() const;
     const QStringList& languages() const;
     const QStringList& worldviews() const;
-    const int indexOfSelectedStyle() const;
+    int indexOfSelectedStyle() const;
 
     Q_INVOKABLE void updateSelectedStyle(const QString& styleName);
     Q_INVOKABLE void loadBasemap(const QString& selectedStrategy, const QString& selectedLanguage, const QString& selectedWorldview);

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -32,8 +32,7 @@ DEFINES += ArcGIS_Runtime_Version=$$ARCGIS_RUNTIME_VERSION
 # This block determines whether to build against the installed SDK or the local dev build area
 exists($$PWD/../../../DevBuildCpp.pri) {
   message("Building against the dev environment")
-  DEFINES += ESRI_BUILD
-  DEFINES += SAMPLE_VIEWER_API_KEY=$$(SAMPLEVIEWERAPIKEY_INTERNAL)
+  DEFINES += SAMPLE_VIEWER_API_KEY=$$(SAMPLEVIEWERAPIKEY_INTERNAL) ESRI_BUILD
 
   # use the Esri dev build script
   include ($$PWD/../../../DevBuildCpp.pri)
@@ -45,7 +44,8 @@ exists($$PWD/../../../DevBuildCpp.pri) {
       $$COMMONVIEWER \
       $$COMMONVIEWER/SyntaxHighlighter \
       $$PWD/../../../api/qt_cpp/Include \
-      $$PWD/../../../api/qt_cpp/Include/LocalServer/
+      $$PWD/../../../api/qt_cpp/Include/LocalServer \
+      $$PWD/../../../../buildnum
 } else {
   message("Building against the installed SDK")
   CONFIG += build_from_setup

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -54,7 +54,7 @@
 #include "DrawOrderLayerListModel.h"
 
 #ifdef ESRI_BUILD
-#include "../../../../../buildnum/buildnum.h"
+#include "buildnum.h"
 #endif
 
 // All CPP Samples


### PR DESCRIPTION
# Description

https://github.com/Esri/arcgis-maps-sdk-samples-qt/commit/c793775217e3485b6d12dc03ee73571303bf8a0d - Fix compiler warning

https://github.com/Esri/arcgis-maps-sdk-samples-qt/commit/4c97500691df956890f0e957a59ba3dcf6696643 - Fix strange build number oddity, _maybe_. For some reason on Windows only, we are getting a bogus build number in the about box. Even stranger, buildnum.h cannot actually be located at the relative path in mainSample.cpp.  This change is speculative so there is no question about where we're looking for the file. I cannot explain how the builds are working now.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement
