### PR TITLE
Jared/api key to access token

### DIFF
--- a/CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -51,22 +51,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayScenesInTabletopAR - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
+++ b/CppSamples/AR/DisplayScenesInTabletopAR/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayScenesInTabletopAR - C++"));
+  app.setApplicationName(QString("DisplayScenesInTabletopAR"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ExploreScenesInFlyoverAR - C++"));
+  app.setApplicationName(QString("ExploreScenesInFlyoverAR"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
+++ b/CppSamples/AR/ExploreScenesInFlyoverAR/main.cpp
@@ -53,22 +53,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ExploreScenesInFlyoverAR - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/CppSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Analyze Hotspots - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/AnalyzeHotspots/main.cpp
+++ b/CppSamples/Analysis/AnalyzeHotspots/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Analyze Hotspots - C++");
+  app.setApplicationName(QString("Analyze Hotspots"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/CppSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Analyze Viewshed - C++");
+  app.setApplicationName(QString("Analyze Viewshed"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/AnalyzeViewshed/main.cpp
+++ b/CppSamples/Analysis/AnalyzeViewshed/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Analyze Viewshed - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   AnalyzeViewshed::init();

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -40,9 +40,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DistanceMeasurementAnalysis - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DistanceMeasurementAnalysis::init();

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -81,6 +81,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DistanceMeasurementAnalysis - C++"));
+  app.setApplicationName(QString("DistanceMeasurementAnalysis"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/main.cpp
@@ -82,35 +82,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Analysis/Geotriggers/main.cpp
+++ b/CppSamples/Analysis/Geotriggers/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("Geotriggers - C++"));
+  app.setApplicationName(QString("Geotriggers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/Geotriggers/main.cpp
+++ b/CppSamples/Analysis/Geotriggers/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Geotriggers - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
     app.setApplicationName(QStringLiteral("LineOfSightGeoElement - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Analysis/LineOfSightGeoElement/main.cpp
+++ b/CppSamples/Analysis/LineOfSightGeoElement/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
     QGuiApplication app(argc, argv);
-    app.setApplicationName(QStringLiteral("LineOfSightGeoElement - C++"));
+    app.setApplicationName(QString("LineOfSightGeoElement"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/CppSamples/Analysis/LineOfSightLocation/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Line of Sight Location - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/LineOfSightLocation/main.cpp
+++ b/CppSamples/Analysis/LineOfSightLocation/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Line of Sight Location - C++");
+  app.setApplicationName(QString("Line of Sight Location"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/StatisticalQuery/main.cpp
+++ b/CppSamples/Analysis/StatisticalQuery/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Statistical Query - C++");
+  app.setApplicationName(QString("Statistical Query"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/StatisticalQuery/main.cpp
+++ b/CppSamples/Analysis/StatisticalQuery/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Statistical Query - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   StatisticalQuery::init();

--- a/CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Statistical Query Group Sort - C++");
+  app.setApplicationName(QString("Statistical Query Group Sort"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
+++ b/CppSamples/Analysis/StatisticalQueryGroupSort/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Statistical Query Group Sort - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   StatisticalQueryGroupSort::init();

--- a/CppSamples/Analysis/ViewshedCamera/main.cpp
+++ b/CppSamples/Analysis/ViewshedCamera/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Viewshed Camera - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/ViewshedCamera/main.cpp
+++ b/CppSamples/Analysis/ViewshedCamera/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Viewshed Camera - C++");
+  app.setApplicationName(QString("Viewshed Camera"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/CppSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Viewshed Geoelement- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/ViewshedGeoElement/main.cpp
+++ b/CppSamples/Analysis/ViewshedGeoElement/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Viewshed Geoelement- C++");
+  app.setApplicationName(QString("Viewshed Geoelement"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Analysis/ViewshedLocation/main.cpp
+++ b/CppSamples/Analysis/ViewshedLocation/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Viewshed Location - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Analysis/ViewshedLocation/main.cpp
+++ b/CppSamples/Analysis/ViewshedLocation/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Viewshed Location - C++");
+  app.setApplicationName(QString("Viewshed Location"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
+++ b/CppSamples/CloudAndPortal/AddItemsToPortal/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Add Items to Portal - C++");
+  app.setApplicationName(QString("Add Items to Portal"));
 
   // Initialize the sample
   AddItemsToPortal::init();

--- a/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IntegratedWindowsAuthentication - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
+++ b/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("IntegratedWindowsAuthentication - C++"));
+  app.setApplicationName(QString("IntegratedWindowsAuthentication"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -42,22 +42,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Portal User Info - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
+++ b/CppSamples/CloudAndPortal/PortalUserInfo/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Portal User Info - C++");
+  app.setApplicationName(QString("Portal User Info"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Search for Webmap - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
+++ b/CppSamples/CloudAndPortal/SearchForWebmap/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Search for Webmap - C++");
+  app.setApplicationName(QString("Search for Webmap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -36,7 +36,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Show Org Basemaps - C++");
+  app.setApplicationName(QString("Show Org Basemaps"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
+++ b/CppSamples/CloudAndPortal/ShowOrgBasemaps/main.cpp
@@ -38,22 +38,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Show Org Basemaps - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND

--- a/CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -42,22 +42,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Token Authentication - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                  "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
+++ b/CppSamples/CloudAndPortal/TokenAuthentication/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Token Authentication - C++");
+  app.setApplicationName(QString("Token Authentication"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("AddGraphicsWithRenderer - C++"));
+  app.setApplicationName(QString("AddGraphicsWithRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddGraphicsWithRenderer - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   AddGraphicsWithRenderer::init();

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/CppSamples/DisplayInformation/BuildLegend/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Build Legend - C++");
+  app.setApplicationName(QString("Build Legend"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/CppSamples/DisplayInformation/BuildLegend/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/CppSamples/DisplayInformation/BuildLegend/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Build Legend - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ControlAnnotationSublayerVisibility - C++"));
+  app.setApplicationName(QString("ControlAnnotationSublayerVisibility"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ControlAnnotationSublayerVisibility - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("CreateSymbolStylesFromWebStyles - C++"));
+  app.setApplicationName(QString("CreateSymbolStylesFromWebStyles"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
+++ b/CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateSymbolStylesFromWebStyles - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CustomDictionaryStyle - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
+++ b/CppSamples/DisplayInformation/CustomDictionaryStyle/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("CustomDictionaryStyle - C++"));
+  app.setApplicationName(QString("CustomDictionaryStyle"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/DisplayClusters/main.cpp
+++ b/CppSamples/DisplayInformation/DisplayClusters/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayClusters - C++"));
+  app.setApplicationName(QString("DisplayClusters"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/DisplayClusters/main.cpp
+++ b/CppSamples/DisplayInformation/DisplayClusters/main.cpp
@@ -29,22 +29,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayClusters - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/CppSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Display Grid - C++");
+  app.setApplicationName(QString("Display Grid"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/DisplayGrid/main.cpp
+++ b/CppSamples/DisplayInformation/DisplayGrid/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Display Grid - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -31,22 +31,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GODictionary Renderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer/main.cpp
@@ -29,7 +29,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GODictionary Renderer - C++");
+  app.setApplicationName(QString("GODictionary Renderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -40,22 +40,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GODictionary Renderer (3D) - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer_3D/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GODictionary Renderer (3D) - C++");
+  app.setApplicationName(QString("GODictionary Renderer (3D)"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/CppSamples/DisplayInformation/GOSymbols/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GOSymbols - C++");
+  app.setApplicationName(QString("GOSymbols"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/CppSamples/DisplayInformation/GOSymbols/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/CppSamples/DisplayInformation/GOSymbols/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GOSymbols - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Identify Graphics - C++");
+  app.setApplicationName(QString("Identify Graphics"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
+++ b/CppSamples/DisplayInformation/IdentifyGraphics/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Identify Graphics - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Picture Marker Symbol - C++");
+  app.setApplicationName(QString("Picture Marker Symbol"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
+++ b/CppSamples/DisplayInformation/Picture_Marker_Symbol/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Picture Marker Symbol - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -77,6 +77,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -33,9 +33,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("QueryFeaturesWithArcadeExpression - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   QueryFeaturesWithArcadeExpression::init();

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -78,35 +78,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -26,8 +26,6 @@
 
 #include "Esri/ArcGISRuntime/Toolkit/register.h"
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/main.cpp
@@ -29,7 +29,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("QueryFeaturesWithArcadeExpression - C++"));
+  app.setApplicationName(QString("QueryFeaturesWithArcadeExpression"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ReadSymbolsFromMobileStyle - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ReadSymbolsFromMobileStyle - C++"));
+  app.setApplicationName(QString("ReadSymbolsFromMobileStyle"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/CppSamples/DisplayInformation/ShowCallout/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Show Callout - C++");
+  app.setApplicationName(QString("Show Callout"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/ShowCallout/main.cpp
+++ b/CppSamples/DisplayInformation/ShowCallout/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Show Callout - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Show Labels on Layers - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
+++ b/CppSamples/DisplayInformation/ShowLabelsOnLayers/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Show Labels on Layers - C++");
+  app.setApplicationName(QString("Show Labels on Layers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/CppSamples/DisplayInformation/ShowPopup/main.cpp
@@ -29,22 +29,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ShowPopup - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/ShowPopup/main.cpp
+++ b/CppSamples/DisplayInformation/ShowPopup/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ShowPopup - C++"));
+  app.setApplicationName(QString("ShowPopup"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Simple Marker Symbol - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
+++ b/CppSamples/DisplayInformation/Simple_Marker_Symbol/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Simple Marker Symbol - C++");
+  app.setApplicationName(QString("Simple Marker Symbol"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/CppSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Simple Renderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/Simple_Renderer/main.cpp
+++ b/CppSamples/DisplayInformation/Simple_Renderer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Simple Renderer - C++");
+  app.setApplicationName(QString("Simple Renderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/CppSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("SketchOnMap - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/SketchOnMap/main.cpp
+++ b/CppSamples/DisplayInformation/SketchOnMap/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("SketchOnMap - C++"));
+  app.setApplicationName(QString("SketchOnMap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Symbolize Shapefile - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
+++ b/CppSamples/DisplayInformation/SymbolizeShapefile/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Symbolize Shapefile - C++");
+  app.setApplicationName(QString("Symbolize Shapefile"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Unique Value Renderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
+++ b/CppSamples/DisplayInformation/Unique_Value_Renderer/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Unique Value Renderer - C++");
+  app.setApplicationName(QString("Unique Value Renderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddFeaturesFeatureService - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   AddFeaturesFeatureService::init();

--- a/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("AddFeaturesFeatureService - C++"));
+  app.setApplicationName(QString("AddFeaturesFeatureService"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/AddFeaturesFeatureService/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/EditData/ContingentValues/main.cpp
+++ b/CppSamples/EditData/ContingentValues/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/EditData/ContingentValues/main.cpp
+++ b/CppSamples/EditData/ContingentValues/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/EditData/ContingentValues/main.cpp
+++ b/CppSamples/EditData/ContingentValues/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/EditData/ContingentValues/main.cpp
+++ b/CppSamples/EditData/ContingentValues/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ContingentValues - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ContingentValues::init();

--- a/CppSamples/EditData/ContingentValues/main.cpp
+++ b/CppSamples/EditData/ContingentValues/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ContingentValues - C++"));
+  app.setApplicationName(QString("ContingentValues"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -33,7 +33,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Delete Features Feature Service - C++");
+  app.setApplicationName(QString("Delete Features Feature Service"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -92,5 +92,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
+++ b/CppSamples/EditData/DeleteFeaturesFeatureService/main.cpp
@@ -35,22 +35,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Delete Features Feature Service - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/CppSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Edit and Sync Features - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/EditAndSyncFeatures/main.cpp
+++ b/CppSamples/EditData/EditAndSyncFeatures/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Edit and Sync Features - C++");
+  app.setApplicationName(QString("Edit and Sync Features"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/CppSamples/EditData/EditFeatureAttachments/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Edit Feature Attachments - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/CppSamples/EditData/EditFeatureAttachments/main.cpp
@@ -90,5 +90,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/EditData/EditFeatureAttachments/main.cpp
+++ b/CppSamples/EditData/EditFeatureAttachments/main.cpp
@@ -34,7 +34,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Edit Feature Attachments - C++");
+  app.setApplicationName(QString("Edit Feature Attachments"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("EditFeaturesWithFeatureLinkedAnnotation - C++"));
+  app.setApplicationName(QString("EditFeaturesWithFeatureLinkedAnnotation"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
+++ b/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("EditFeaturesWithFeatureLinkedAnnotation - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("EditKmlGroundOverlay - C++"));
+  app.setApplicationName(QString("EditKmlGroundOverlay"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/EditKmlGroundOverlay/main.cpp
+++ b/CppSamples/EditData/EditKmlGroundOverlay/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("EditKmlGroundOverlay - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/CppSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -37,22 +37,30 @@ int main(int argc, char *argv[])
   QtWebEngineQuick::initialize();
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                  "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/EditWithBranchVersioning/main.cpp
+++ b/CppSamples/EditData/EditWithBranchVersioning/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("EditWithBranchVersioning - C++"));
+  app.setApplicationName(QString("EditWithBranchVersioning"));
 
 #ifdef QT_WEBVIEW_WEBENGINE_BACKEND
   QtWebEngineQuick::initialize();

--- a/CppSamples/EditData/SnapGeometryEdits/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/main.cpp
@@ -23,7 +23,7 @@
 #include <Windows.h>
 #endif
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("SnapGeometryEdits - C++"));

--- a/CppSamples/EditData/SnapGeometryEdits/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/main.cpp
@@ -72,34 +72,3 @@ int main(int argc, char* argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                 << "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}

--- a/CppSamples/EditData/SnapGeometryEdits/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/main.cpp
@@ -30,9 +30,31 @@ int main(int argc, char* argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("SnapGeometryEdits - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   SnapGeometryEdits::init();

--- a/CppSamples/EditData/SnapGeometryEdits/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/main.cpp
@@ -26,7 +26,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("SnapGeometryEdits - C++"));
+  app.setApplicationName(QString("SnapGeometryEdits"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/SnapGeometryEdits/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/main.cpp
@@ -23,8 +23,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char* argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/EditData/SnapGeometryEdits/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/main.cpp
@@ -71,4 +71,3 @@ int main(int argc, char* argv[])
 
   return app.exec();
 }
-

--- a/CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -35,22 +35,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Update Attributes Feature Service - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -33,7 +33,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Update Attributes Feature Service - C++");
+  app.setApplicationName(QString("Update Attributes Feature Service"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
+++ b/CppSamples/EditData/UpdateAttributesFeatureService/main.cpp
@@ -92,5 +92,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Update Geometry Feature Service - C++");
+  app.setApplicationName(QString("Update Geometry Feature Service"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
+++ b/CppSamples/EditData/UpdateGeometryFeatureService/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Update Geometry Feature Service - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ControlTimeExtentTimeSlider - C++"));
+  app.setApplicationName(QString("ControlTimeExtentTimeSlider"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -32,9 +32,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ControlTimeExtentTimeSlider - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ControlTimeExtentTimeSlider::init();

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -75,5 +75,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/main.cpp
@@ -76,36 +76,4 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("CreateMobileGeodatabase - C++"));
+  app.setApplicationName(QString("CreateMobileGeodatabase"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Features/CreateMobileGeodatabase/main.cpp
+++ b/CppSamples/Features/CreateMobileGeodatabase/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("CreateMobileGeodatabase - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   CreateMobileGeodatabase::init();

--- a/CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
+++ b/CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerChangeRenderer- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
+++ b/CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
+++ b/CppSamples/Features/FeatureLayerChangeRenderer/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FeatureLayerChangeRenderer- C++");
+  app.setApplicationName(QString("FeatureLayerChangeRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
+++ b/CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
@@ -31,22 +31,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerDictionaryRenderer- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   FeatureLayerDictionaryRenderer::init();

--- a/CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
+++ b/CppSamples/Features/FeatureLayerDictionaryRenderer/main.cpp
@@ -29,7 +29,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FeatureLayerDictionaryRenderer- C++");
+  app.setApplicationName(QString("FeatureLayerDictionaryRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/FeatureLayerQuery/main.cpp
+++ b/CppSamples/Features/FeatureLayerQuery/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FeatureLayerQuery- C++");
+  app.setApplicationName(QString("FeatureLayerQuery"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/FeatureLayerQuery/main.cpp
+++ b/CppSamples/Features/FeatureLayerQuery/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/FeatureLayerQuery/main.cpp
+++ b/CppSamples/Features/FeatureLayerQuery/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerQuery- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("FeatureLayerSelection - C++"));
+  app.setApplicationName(QString("FeatureLayerSelection"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Features/FeatureLayerSelection/main.cpp
+++ b/CppSamples/Features/FeatureLayerSelection/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("FeatureLayerSelection - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   FeatureLayerSelection::init();

--- a/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FilterByDefinitionExpressionOrDisplayFilter- C++");
+  app.setApplicationName(QString("FilterByDefinitionExpressionOrDisplayFilter"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -95,5 +95,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
+++ b/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FilterByDefinitionExpressionOrDisplayFilter- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateGeodatabaseReplicaFromFeatureService- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
+++ b/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GenerateGeodatabaseReplicaFromFeatureService- C++");
+  app.setApplicationName(QString("GenerateGeodatabaseReplicaFromFeatureService"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/ListRelatedFeatures/main.cpp
+++ b/CppSamples/Features/ListRelatedFeatures/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListRelatedFeatures- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample.

--- a/CppSamples/Features/ListRelatedFeatures/main.cpp
+++ b/CppSamples/Features/ListRelatedFeatures/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ListRelatedFeatures- C++");
+  app.setApplicationName(QString("ListRelatedFeatures"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/ServiceFeatureTableCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableCache/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTableCache- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/ServiceFeatureTableCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableCache/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/ServiceFeatureTableCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableCache/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ServiceFeatureTableCache- C++");
+  app.setApplicationName(QString("ServiceFeatureTableCache"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ServiceFeatureTableManualCache- C++");
+  app.setApplicationName(QString("ServiceFeatureTableManualCache"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableManualCache/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTableManualCache- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceFeatureTableNoCache- C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ServiceFeatureTableNoCache- C++");
+  app.setApplicationName(QString("ServiceFeatureTableNoCache"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
+++ b/CppSamples/Features/ServiceFeatureTableNoCache/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Geometry/Buffer/main.cpp
+++ b/CppSamples/Geometry/Buffer/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Geometry/Buffer/main.cpp
+++ b/CppSamples/Geometry/Buffer/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("Buffer - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   Buffer::init();

--- a/CppSamples/Geometry/Buffer/main.cpp
+++ b/CppSamples/Geometry/Buffer/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Geometry/Buffer/main.cpp
+++ b/CppSamples/Geometry/Buffer/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("Buffer - C++"));
+  app.setApplicationName(QString("Buffer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/Buffer/main.cpp
+++ b/CppSamples/Geometry/Buffer/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Geometry/ClipGeometry/main.cpp
+++ b/CppSamples/Geometry/ClipGeometry/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Clip geometry - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/ClipGeometry/main.cpp
+++ b/CppSamples/Geometry/ClipGeometry/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("Clip geometry - C++"));
+  app.setApplicationName(QString("Clip geometry"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/ConvexHull/main.cpp
+++ b/CppSamples/Geometry/ConvexHull/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ConvexHull - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/ConvexHull/main.cpp
+++ b/CppSamples/Geometry/ConvexHull/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ConvexHull - C++"));
+  app.setApplicationName(QString("ConvexHull"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -72,4 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-

--- a/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -73,35 +73,3 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-          "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
-

--- a/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("CreateAndEditGeometries - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   CreateAndEditGeometries::init();

--- a/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateAndEditGeometries/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("CreateAndEditGeometries - C++"));
+  app.setApplicationName(QString("CreateAndEditGeometries"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/CreateGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateGeometries/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("CreateGeometries - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/CreateGeometries/main.cpp
+++ b/CppSamples/Geometry/CreateGeometries/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("CreateGeometries - C++");
+  app.setApplicationName(QString("CreateGeometries"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/CutGeometry/main.cpp
+++ b/CppSamples/Geometry/CutGeometry/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("CutGeometry - C++");
+  app.setApplicationName(QString("CutGeometry"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/CutGeometry/main.cpp
+++ b/CppSamples/Geometry/CutGeometry/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("CutGeometry - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/DensifyAndGeneralize/main.cpp
+++ b/CppSamples/Geometry/DensifyAndGeneralize/main.cpp
@@ -31,22 +31,30 @@ int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/FormatCoordinates/main.cpp
+++ b/CppSamples/Geometry/FormatCoordinates/main.cpp
@@ -35,22 +35,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FormatCoordinates - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/FormatCoordinates/main.cpp
+++ b/CppSamples/Geometry/FormatCoordinates/main.cpp
@@ -86,5 +86,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Geometry/FormatCoordinates/main.cpp
+++ b/CppSamples/Geometry/FormatCoordinates/main.cpp
@@ -33,7 +33,7 @@ using namespace Esri::ArcGISRuntime;
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FormatCoordinates - C++");
+  app.setApplicationName(QString("FormatCoordinates"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/GeodesicOperations/main.cpp
+++ b/CppSamples/Geometry/GeodesicOperations/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GeodesicOperations - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/GeodesicOperations/main.cpp
+++ b/CppSamples/Geometry/GeodesicOperations/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GeodesicOperations - C++");
+  app.setApplicationName(QString("GeodesicOperations"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/ListTransformations/main.cpp
+++ b/CppSamples/Geometry/ListTransformations/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ListTransformations - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/ListTransformations/main.cpp
+++ b/CppSamples/Geometry/ListTransformations/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ListTransformations - C++");
+  app.setApplicationName(QString("ListTransformations"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/NearestVertex/main.cpp
+++ b/CppSamples/Geometry/NearestVertex/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("NearestVertex - C++"));
+  app.setApplicationName(QString("NearestVertex"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/NearestVertex/main.cpp
+++ b/CppSamples/Geometry/NearestVertex/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NearestVertex - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/ProjectGeometry/main.cpp
+++ b/CppSamples/Geometry/ProjectGeometry/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ProjectGeometry - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/ProjectGeometry/main.cpp
+++ b/CppSamples/Geometry/ProjectGeometry/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ProjectGeometry - C++");
+  app.setApplicationName(QString("ProjectGeometry"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/SpatialOperations/main.cpp
+++ b/CppSamples/Geometry/SpatialOperations/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SpatialOperations - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Geometry/SpatialOperations/main.cpp
+++ b/CppSamples/Geometry/SpatialOperations/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SpatialOperations - C++");
+  app.setApplicationName(QString("SpatialOperations"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/SpatialRelationships/main.cpp
+++ b/CppSamples/Geometry/SpatialRelationships/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SpatialRelationships - C++");
+  app.setApplicationName(QString("SpatialRelationships"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Geometry/SpatialRelationships/main.cpp
+++ b/CppSamples/Geometry/SpatialRelationships/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SpatialRelationships - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
@@ -75,6 +75,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
@@ -32,9 +32,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddCustomDynamicEntityDataSource - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   AddCustomDynamicEntityDataSource::init();

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("AddCustomDynamicEntityDataSource - C++"));
+  app.setApplicationName(QString("AddCustomDynamicEntityDataSource"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/main.cpp
@@ -76,35 +76,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("AddDynamicEntityLayer - C++"));
+  app.setApplicationName(QString("AddDynamicEntityLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("AddDynamicEntityLayer - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   AddDynamicEntityLayer::init();

--- a/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -73,34 +73,4 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}

--- a/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
+++ b/CppSamples/Layers/AddDynamicEntityLayer/main.cpp
@@ -72,5 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/CppSamples/Layers/AddEncExchangeSet/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("AddEncExchangeSet - C++"));
+  app.setApplicationName(QString("AddEncExchangeSet"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/AddEncExchangeSet/main.cpp
+++ b/CppSamples/Layers/AddEncExchangeSet/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("AddEncExchangeSet - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ApplyMosaicRuleToRasters - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
+++ b/CppSamples/Layers/ApplyMosaicRuleToRasters/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ApplyMosaicRuleToRasters - C++"));
+  app.setApplicationName(QString("ApplyMosaicRuleToRasters"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ApplyUniqueValuesWithAlternateSymbols - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ApplyUniqueValuesWithAlternateSymbols::init();

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ApplyUniqueValuesWithAlternateSymbols - C++"));
+  app.setApplicationName(QString("ApplyUniqueValuesWithAlternateSymbols"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -34,7 +34,7 @@ using namespace Esri::ArcGISRuntime;
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ArcGISMapImageLayerUrl - C++");
+  app.setApplicationName(QString("ArcGISMapImageLayerUrl"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ArcGISMapImageLayerUrl - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
+++ b/CppSamples/Layers/ArcGISMapImageLayerUrl/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ArcGISTiledLayerUrl - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -34,7 +34,7 @@ using namespace Esri::ArcGISRuntime;
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ArcGISTiledLayerUrl - C++");
+  app.setApplicationName(QString("ArcGISTiledLayerUrl"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/CppSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -91,5 +91,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/BlendRasterLayer/main.cpp
+++ b/CppSamples/Layers/BlendRasterLayer/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("BlendRasterLayer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/BlendRasterLayer/main.cpp
+++ b/CppSamples/Layers/BlendRasterLayer/main.cpp
@@ -32,7 +32,7 @@ using namespace Esri::ArcGISRuntime;
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("BlendRasterLayer - C++");
+  app.setApplicationName(QString("BlendRasterLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("BrowseOGCAPIFeatureService - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                  "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
+++ b/CppSamples/Layers/BrowseOGCAPIFeatureService/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("BrowseOGCAPIFeatureService - C++"));
+  app.setApplicationName(QString("BrowseOGCAPIFeatureService"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/CppSamples/Layers/BrowseWfsLayers/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("BrowseWfsLayers - C++"));
+  app.setApplicationName(QString("BrowseWfsLayers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/BrowseWfsLayers/main.cpp
+++ b/CppSamples/Layers/BrowseWfsLayers/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("BrowseWfsLayers - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/CppSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeSublayerRenderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   ChangeSublayerRenderer::init();

--- a/CppSamples/Layers/ChangeSublayerRenderer/main.cpp
+++ b/CppSamples/Layers/ChangeSublayerRenderer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ChangeSublayerRenderer - C++");
+  app.setApplicationName(QString("ChangeSublayerRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/CppSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -89,5 +89,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/CppSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -33,7 +33,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ChangeSublayerVisibility - C++");
+  app.setApplicationName(QString("ChangeSublayerVisibility"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ChangeSublayerVisibility/main.cpp
+++ b/CppSamples/Layers/ChangeSublayerVisibility/main.cpp
@@ -35,22 +35,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeSublayerVisibility - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   ChangeSublayerVisibility::init();

--- a/CppSamples/Layers/ConfigureClusters/main.cpp
+++ b/CppSamples/Layers/ConfigureClusters/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/ConfigureClusters/main.cpp
+++ b/CppSamples/Layers/ConfigureClusters/main.cpp
@@ -73,6 +73,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Layers/ConfigureClusters/main.cpp
+++ b/CppSamples/Layers/ConfigureClusters/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ConfigureClusters - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ConfigureClusters::init();

--- a/CppSamples/Layers/ConfigureClusters/main.cpp
+++ b/CppSamples/Layers/ConfigureClusters/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ConfigureClusters - C++"));
+  app.setApplicationName(QString("ConfigureClusters"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ConfigureClusters/main.cpp
+++ b/CppSamples/Layers/ConfigureClusters/main.cpp
@@ -74,35 +74,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateAndSaveKmlFile - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
+++ b/CppSamples/Layers/CreateAndSaveKmlFile/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("CreateAndSaveKmlFile - C++"));
+  app.setApplicationName(QString("CreateAndSaveKmlFile"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayAnnotation - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Layers/DisplayAnnotation/main.cpp
+++ b/CppSamples/Layers/DisplayAnnotation/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayAnnotation - C++"));
+  app.setApplicationName(QString("DisplayAnnotation"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/CppSamples/Layers/DisplayDimensions/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/CppSamples/Layers/DisplayDimensions/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayDimensions - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DisplayDimensions::init();

--- a/CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/CppSamples/Layers/DisplayDimensions/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/CppSamples/Layers/DisplayDimensions/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Layers/DisplayDimensions/main.cpp
+++ b/CppSamples/Layers/DisplayDimensions/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DisplayDimensions - C++"));
+  app.setApplicationName(QString("DisplayDimensions"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/CppSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/CppSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayFeatureLayers - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DisplayFeatureLayers::init();

--- a/CppSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/CppSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -73,34 +73,4 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}

--- a/CppSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/CppSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -72,5 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/DisplayFeatureLayers/main.cpp
+++ b/CppSamples/Layers/DisplayFeatureLayers/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DisplayFeatureLayers - C++"));
+  app.setApplicationName(QString("DisplayFeatureLayers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayKml/main.cpp
+++ b/CppSamples/Layers/DisplayKml/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayKml - C++"));
+  app.setApplicationName(QString("DisplayKml"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayKml/main.cpp
+++ b/CppSamples/Layers/DisplayKml/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayKml - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayKmlNetworkLinks - C++"));
+  app.setApplicationName(QString("DisplayKmlNetworkLinks"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
+++ b/CppSamples/Layers/DisplayKmlNetworkLinks/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayKmlNetworkLinks - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -28,22 +28,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayOgcApiFeatureCollection - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                  "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
+++ b/CppSamples/Layers/DisplayOgcApiFeatureCollection/main.cpp
@@ -26,7 +26,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayOgcApiFeatureCollection - C++"));
+  app.setApplicationName(QString("DisplayOgcApiFeatureCollection"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplaySubtypeFeatureLayer - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
+++ b/CppSamples/Layers/DisplaySubtypeFeatureLayer/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplaySubtypeFeatureLayer - C++"));
+  app.setApplicationName(QString("DisplaySubtypeFeatureLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/CppSamples/Layers/DisplayWfsLayer/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayWfsLayer - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/DisplayWfsLayer/main.cpp
+++ b/CppSamples/Layers/DisplayWfsLayer/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayWfsLayer - C++"));
+  app.setApplicationName(QString("DisplayWfsLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ExportTiles/main.cpp
+++ b/CppSamples/Layers/ExportTiles/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ExportTiles - C++");
+  app.setApplicationName(QString("ExportTiles"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ExportTiles/main.cpp
+++ b/CppSamples/Layers/ExportTiles/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/ExportTiles/main.cpp
+++ b/CppSamples/Layers/ExportTiles/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ExportTiles - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ExportVectorTiles - C++"));
+  app.setApplicationName(QString("ExportVectorTiles"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Layers/ExportVectorTiles/main.cpp
+++ b/CppSamples/Layers/ExportVectorTiles/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ExportVectorTiles - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ExportVectorTiles::init();

--- a/CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FeatureCollectionLayerFromPortal - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
+++ b/CppSamples/Layers/FeatureCollectionLayerFromPortal/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("FeatureCollectionLayerFromPortal - C++"));
+  app.setApplicationName(QString("FeatureCollectionLayerFromPortal"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureCollectionLayerQuery - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     //Initialize the sample

--- a/CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
+++ b/CppSamples/Layers/FeatureCollectionLayerQuery/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FeatureCollectionLayerQuery - C++");
+  app.setApplicationName(QString("FeatureCollectionLayerQuery"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FeatureLayerRenderingModeMap - C++");
+  app.setApplicationName(QString("FeatureLayerRenderingModeMap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
+++ b/CppSamples/Layers/FeatureLayerRenderingModeMap/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerRenderingModeMap - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FeatureLayerRenderingModeScene - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
   // Initialize the sample
   FeatureLayerRenderingModeScene::init();

--- a/CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
+++ b/CppSamples/Layers/FeatureLayerRenderingModeScene/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FeatureLayerRenderingModeScene - C++");
+  app.setApplicationName(QString("FeatureLayerRenderingModeScene"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/CppSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Feature_Collection_Layer - C++");
+  app.setApplicationName(QString("Feature_Collection_Layer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/Feature_Collection_Layer/main.cpp
+++ b/CppSamples/Layers/Feature_Collection_Layer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Feature_Collection_Layer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   //Initialize the sample

--- a/CppSamples/Layers/GroupLayers/main.cpp
+++ b/CppSamples/Layers/GroupLayers/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("GroupLayers - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/GroupLayers/main.cpp
+++ b/CppSamples/Layers/GroupLayers/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("GroupLayers - C++"));
+  app.setApplicationName(QString("GroupLayers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/CppSamples/Layers/Hillshade_Renderer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Hillshade_Renderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/Hillshade_Renderer/main.cpp
+++ b/CppSamples/Layers/Hillshade_Renderer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Hillshade_Renderer - C++");
+  app.setApplicationName(QString("Hillshade_Renderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/CppSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("IdentifyKmlFeatures - C++"));
+  app.setApplicationName(QString("IdentifyKmlFeatures"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/IdentifyKmlFeatures/main.cpp
+++ b/CppSamples/Layers/IdentifyKmlFeatures/main.cpp
@@ -29,22 +29,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IdentifyKmlFeatures - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/CppSamples/Layers/IdentifyRasterCell/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("IdentifyRasterCell - C++"));
+  app.setApplicationName(QString("IdentifyRasterCell"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/IdentifyRasterCell/main.cpp
+++ b/CppSamples/Layers/IdentifyRasterCell/main.cpp
@@ -29,22 +29,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("IdentifyRasterCell - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ListKmlContents/main.cpp
+++ b/CppSamples/Layers/ListKmlContents/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ListKmlContents - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                  "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ListKmlContents/main.cpp
+++ b/CppSamples/Layers/ListKmlContents/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ListKmlContents - C++"));
+  app.setApplicationName(QString("ListKmlContents"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/CppSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("LoadWfsXmlQuery - C++"));
+  app.setApplicationName(QString("LoadWfsXmlQuery"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/LoadWfsXmlQuery/main.cpp
+++ b/CppSamples/Layers/LoadWfsXmlQuery/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("LoadWfsXmlQuery - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/CppSamples/Layers/ManageOperationalLayers/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ManageOperationalLayers - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/ManageOperationalLayers/main.cpp
+++ b/CppSamples/Layers/ManageOperationalLayers/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ManageOperationalLayers - C++"));
+  app.setApplicationName(QString("ManageOperationalLayers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/OSM_Layer/main.cpp
+++ b/CppSamples/Layers/OSM_Layer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("OSM_Layer - C++");
+  app.setApplicationName(QString("OSM_Layer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/OSM_Layer/main.cpp
+++ b/CppSamples/Layers/OSM_Layer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("OSM_Layer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("PlayAKmlTour - C++"));
+  app.setApplicationName(QString("PlayAKmlTour"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/PlayAKmlTour/main.cpp
+++ b/CppSamples/Layers/PlayAKmlTour/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("PlayAKmlTour - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/QueryMapImageSublayer/main.cpp
+++ b/CppSamples/Layers/QueryMapImageSublayer/main.cpp
@@ -31,22 +31,30 @@ int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -72,5 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -73,36 +73,4 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("QueryOGCAPICQLFilters - C++"));
+  app.setApplicationName(QString("QueryOGCAPICQLFilters"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("QueryOGCAPICQLFilters - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   QueryOGCAPICQLFilters::init();

--- a/CppSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/CppSamples/Layers/RasterColormapRenderer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterColormapRenderer - C++");
+  app.setApplicationName(QString("RasterColormapRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterColormapRenderer/main.cpp
+++ b/CppSamples/Layers/RasterColormapRenderer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterColormapRenderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   //Initialize the sample

--- a/CppSamples/Layers/RasterFunctionFile/main.cpp
+++ b/CppSamples/Layers/RasterFunctionFile/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterFunctionFile - C++");
+  app.setApplicationName(QString("RasterFunctionFile"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterFunctionFile/main.cpp
+++ b/CppSamples/Layers/RasterFunctionFile/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterFunctionFile - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   //Initialize the sample

--- a/CppSamples/Layers/RasterFunctionService/main.cpp
+++ b/CppSamples/Layers/RasterFunctionService/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterFunctionService - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   //Initialize the sample

--- a/CppSamples/Layers/RasterFunctionService/main.cpp
+++ b/CppSamples/Layers/RasterFunctionService/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterFunctionService - C++");
+  app.setApplicationName(QString("RasterFunctionService"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterLayerFile/main.cpp
+++ b/CppSamples/Layers/RasterLayerFile/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterLayerFile - C++");
+  app.setApplicationName(QString("RasterLayerFile"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterLayerFile/main.cpp
+++ b/CppSamples/Layers/RasterLayerFile/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerFile - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/CppSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterLayerGeoPackage - C++");
+  app.setApplicationName(QString("RasterLayerGeoPackage"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterLayerGeoPackage/main.cpp
+++ b/CppSamples/Layers/RasterLayerGeoPackage/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerGeoPackage - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/RasterLayerService/main.cpp
+++ b/CppSamples/Layers/RasterLayerService/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterLayerService - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/RasterLayerService/main.cpp
+++ b/CppSamples/Layers/RasterLayerService/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterLayerService - C++");
+  app.setApplicationName(QString("RasterLayerService"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterRenderingRule/main.cpp
+++ b/CppSamples/Layers/RasterRenderingRule/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterRenderingRule - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/RasterRenderingRule/main.cpp
+++ b/CppSamples/Layers/RasterRenderingRule/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterRenderingRule - C++");
+  app.setApplicationName(QString("RasterRenderingRule"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/CppSamples/Layers/RasterRgbRenderer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterRgbRenderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/RasterRgbRenderer/main.cpp
+++ b/CppSamples/Layers/RasterRgbRenderer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterRgbRenderer - C++");
+  app.setApplicationName(QString("RasterRgbRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/CppSamples/Layers/RasterStretchRenderer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("RasterStretchRenderer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/RasterStretchRenderer/main.cpp
+++ b/CppSamples/Layers/RasterStretchRenderer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("RasterStretchRenderer - C++");
+  app.setApplicationName(QString("RasterStretchRenderer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/StyleWmsLayer/main.cpp
+++ b/CppSamples/Layers/StyleWmsLayer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("StyleWmsLayer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/StyleWmsLayer/main.cpp
+++ b/CppSamples/Layers/StyleWmsLayer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("StyleWmsLayer - C++");
+  app.setApplicationName(QString("StyleWmsLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/TileCacheLayer/main.cpp
+++ b/CppSamples/Layers/TileCacheLayer/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("TileCacheLayer - C++"));
+  app.setApplicationName(QString("TileCacheLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/TileCacheLayer/main.cpp
+++ b/CppSamples/Layers/TileCacheLayer/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("TileCacheLayer - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/CppSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("VectorTiledLayerUrl - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/CppSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("VectorTiledLayerUrl - C++");
+  app.setApplicationName(QString("VectorTiledLayerUrl"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/VectorTiledLayerUrl/main.cpp
+++ b/CppSamples/Layers/VectorTiledLayerUrl/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Layers/WMTS_Layer/main.cpp
+++ b/CppSamples/Layers/WMTS_Layer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("WMTS_Layer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/WMTS_Layer/main.cpp
+++ b/CppSamples/Layers/WMTS_Layer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("WMTS_Layer - C++");
+  app.setApplicationName(QString("WMTS_Layer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/CppSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Web_Tiled_Layer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Layers/Web_Tiled_Layer/main.cpp
+++ b/CppSamples/Layers/Web_Tiled_Layer/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Web_Tiled_Layer - C++");
+  app.setApplicationName(QString("Web_Tiled_Layer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/WmsLayerUrl/main.cpp
+++ b/CppSamples/Layers/WmsLayerUrl/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("WmsLayerUrl - C++");
+  app.setApplicationName(QString("WmsLayerUrl"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Layers/WmsLayerUrl/main.cpp
+++ b/CppSamples/Layers/WmsLayerUrl/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("WmsLayerUrl - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
+++ b/CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerFeatureLayer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
+++ b/CppSamples/LocalServer/LocalServerFeatureLayer/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("LocalServerFeatureLayer - C++");
+  app.setApplicationName(QString("LocalServerFeatureLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
+++ b/CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerGeoprocessing - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
+++ b/CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
+++ b/CppSamples/LocalServer/LocalServerGeoprocessing/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("LocalServerGeoprocessing - C++");
+  app.setApplicationName(QString("LocalServerGeoprocessing"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
+++ b/CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerMapImageLayer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
+++ b/CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
+++ b/CppSamples/LocalServer/LocalServerMapImageLayer/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("LocalServerMapImageLayer - C++");
+  app.setApplicationName(QString("LocalServerMapImageLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/LocalServer/LocalServerServices/main.cpp
+++ b/CppSamples/LocalServer/LocalServerServices/main.cpp
@@ -86,5 +86,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/LocalServer/LocalServerServices/main.cpp
+++ b/CppSamples/LocalServer/LocalServerServices/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("LocalServerServices - C++");
+  app.setApplicationName(QString("LocalServerServices"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/LocalServer/LocalServerServices/main.cpp
+++ b/CppSamples/LocalServer/LocalServerServices/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("LocalServerServices - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ApplyScheduledMapUpdates - C++"));
+  app.setApplicationName(QString("ApplyScheduledMapUpdates"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
+++ b/CppSamples/Maps/ApplyScheduledMapUpdates/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ApplyScheduledMapUpdates - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("BrowseBuildingFloors - C++"));
+  app.setApplicationName(QString("BrowseBuildingFloors"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -72,5 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -73,36 +73,4 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                    " you to authenticate with an ArcGIS identity or set the API Key property.";
-
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Maps/BrowseBuildingFloors/main.cpp
+++ b/CppSamples/Maps/BrowseBuildingFloors/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("BrowseBuildingFloors - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   BrowseBuildingFloors::init();

--- a/CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/CppSamples/Maps/ChangeBasemap/main.cpp
@@ -76,5 +76,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/CppSamples/Maps/ChangeBasemap/main.cpp
@@ -32,9 +32,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ChangeBasemap - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ChangeBasemap::init();

--- a/CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/CppSamples/Maps/ChangeBasemap/main.cpp
@@ -77,36 +77,4 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/CppSamples/Maps/ChangeBasemap/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/ChangeBasemap/main.cpp
+++ b/CppSamples/Maps/ChangeBasemap/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ChangeBasemap - C++"));
+  app.setApplicationName(QString("ChangeBasemap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ChangeViewpoint/main.cpp
+++ b/CppSamples/Maps/ChangeViewpoint/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/ChangeViewpoint/main.cpp
+++ b/CppSamples/Maps/ChangeViewpoint/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ChangeViewpoint - C++");
+  app.setApplicationName(QString("ChangeViewpoint"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ChangeViewpoint/main.cpp
+++ b/CppSamples/Maps/ChangeViewpoint/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ChangeViewpoint - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
@@ -24,7 +24,7 @@
 #include <Windows.h>
 #endif
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ConfigureBasemapStyleLanguage - C++"));

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char* argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
@@ -73,34 +73,3 @@ int main(int argc, char* argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires"
-                 << "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
@@ -72,4 +72,3 @@ int main(int argc, char* argv[])
 
   return app.exec();
 }
-

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char* argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ConfigureBasemapStyleLanguage - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ConfigureBasemapStyleLanguage::init();

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ConfigureBasemapStyleLanguage - C++"));
+  app.setApplicationName(QString("ConfigureBasemapStyleLanguage"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/CreateAndSaveMap/main.cpp
+++ b/CppSamples/Maps/CreateAndSaveMap/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("CreateAndSaveMap - C++");
+  app.setApplicationName(QString("CreateAndSaveMap"));
 
   // Initialize the sample
   CreateAndSaveMap::init();

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
-    app.setApplicationName(QString("CreateDynamicBasemapGallery - C++"));
+    app.setApplicationName(QString("CreateDynamicBasemapGallery"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication &app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
     QGuiApplication app(argc, argv);
     app.setApplicationName(QString("CreateDynamicBasemapGallery - C++"));
 
-    // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-    const QString apiKey = QString("");
-    setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
     // Initialize the sample
     CreateDynamicBasemapGallery::init();

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/main.cpp
@@ -72,37 +72,3 @@ int main(int argc, char *argv[])
 
     return app.exec();
 }
-
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication &app, QString apiKey)
-{
-    if (apiKey.isEmpty()) {
-        // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-        QCommandLineParser cmdParser;
-        QCommandLineOption
-            apiKeyArgument(QStringList{"k", "api"},
-                           "The API Key property used to access Esri location services",
-                           "apiKeyInput");
-        cmdParser.addOption(apiKeyArgument);
-        cmdParser.process(app);
-
-        apiKey = cmdParser.value(apiKeyArgument);
-
-        if (apiKey.isEmpty()) {
-            qWarning()
-                << "Use of Esri location services, including basemaps, requires"
-                << "you to authenticate with an ArcGIS identity or set the API Key property.";
-            return;
-        }
-    }
-
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}

--- a/CppSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("DisplayDeviceLocation - C++");
+  app.setApplicationName(QString("DisplayDeviceLocation"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DisplayDeviceLocation/main.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayDeviceLocation - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
  // Initialize the sample

--- a/CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayDeviceLocationWithNmeaDataSources - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocationWithNmeaDataSources/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayDeviceLocationWithNmeaDataSources - C++"));
+  app.setApplicationName(QString("DisplayDeviceLocationWithNmeaDataSources"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/CppSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("DisplayDrawingStatus - C++");
+  app.setApplicationName(QString("DisplayDrawingStatus"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DisplayDrawingStatus/main.cpp
+++ b/CppSamples/Maps/DisplayDrawingStatus/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplayDrawingStatus - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayLayerViewDrawState - C++"));
+  app.setApplicationName(QString("DisplayLayerViewDrawState"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
+++ b/CppSamples/Maps/DisplayLayerViewDrawState/main.cpp
@@ -29,22 +29,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayLayerViewDrawState - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/DisplayMap/main.cpp
+++ b/CppSamples/Maps/DisplayMap/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/DisplayMap/main.cpp
+++ b/CppSamples/Maps/DisplayMap/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DisplayMap - C++"));
+  app.setApplicationName(QString("DisplayMap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DisplayMap/main.cpp
+++ b/CppSamples/Maps/DisplayMap/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayMap - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DisplayMap::init();

--- a/CppSamples/Maps/DisplayMap/main.cpp
+++ b/CppSamples/Maps/DisplayMap/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Maps/DisplayMap/main.cpp
+++ b/CppSamples/Maps/DisplayMap/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DisplayOverviewMap - C++"));
+  app.setApplicationName(QString("DisplayOverviewMap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -32,9 +32,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayOverviewMap - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DisplayOverviewMap::init();

--- a/CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -77,36 +77,3 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
-

--- a/CppSamples/Maps/DisplayOverviewMap/main.cpp
+++ b/CppSamples/Maps/DisplayOverviewMap/main.cpp
@@ -76,4 +76,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-

--- a/CppSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/CppSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DownloadPreplannedMap - C++"));
+  app.setApplicationName(QString("DownloadPreplannedMap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/DownloadPreplannedMap/main.cpp
+++ b/CppSamples/Maps/DownloadPreplannedMap/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DownloadPreplannedMap - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/CppSamples/Maps/GenerateOfflineMap/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GenerateOfflineMap - C++");
+  app.setApplicationName(QString("GenerateOfflineMap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/GenerateOfflineMap/main.cpp
+++ b/CppSamples/Maps/GenerateOfflineMap/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMap - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMapLocalBasemap - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
+++ b/CppSamples/Maps/GenerateOfflineMapLocalBasemap/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GenerateOfflineMapLocalBasemap - C++");
+  app.setApplicationName(QString("GenerateOfflineMapLocalBasemap"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("GenerateOfflineMap_Overrides - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
+++ b/CppSamples/Maps/GenerateOfflineMap_Overrides/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("GenerateOfflineMap_Overrides - C++");
+  app.setApplicationName(QString("GenerateOfflineMap_Overrides"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("HonorMobileMapPackageExpiration - C++"));
+  app.setApplicationName(QString("HonorMobileMapPackageExpiration"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
+++ b/CppSamples/Maps/HonorMobileMapPackageExpiration/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("HonorMobileMapPackageExpiration - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/IdentifyLayers/main.cpp
+++ b/CppSamples/Maps/IdentifyLayers/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("IdentifyLayers - C++");
+  app.setApplicationName(QString("IdentifyLayers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/IdentifyLayers/main.cpp
+++ b/CppSamples/Maps/IdentifyLayers/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("IdentifyLayers - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/ManageBookmarks/main.cpp
+++ b/CppSamples/Maps/ManageBookmarks/main.cpp
@@ -96,5 +96,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/ManageBookmarks/main.cpp
+++ b/CppSamples/Maps/ManageBookmarks/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ManageBookmarks - C++");
+  app.setApplicationName(QString("ManageBookmarks"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ManageBookmarks/main.cpp
+++ b/CppSamples/Maps/ManageBookmarks/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ManageBookmarks - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/MapLoaded/main.cpp
+++ b/CppSamples/Maps/MapLoaded/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("MapLoaded - C++");
+  app.setApplicationName(QString("MapLoaded"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/MapLoaded/main.cpp
+++ b/CppSamples/Maps/MapLoaded/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("MapLoaded - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/MapLoaded/main.cpp
+++ b/CppSamples/Maps/MapLoaded/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/MapReferenceScale/main.cpp
+++ b/CppSamples/Maps/MapReferenceScale/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("MapReferenceScale - C++"));
+  app.setApplicationName(QString("MapReferenceScale"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/MapReferenceScale/main.cpp
+++ b/CppSamples/Maps/MapReferenceScale/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("MapReferenceScale - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/MapRotation/main.cpp
+++ b/CppSamples/Maps/MapRotation/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("MapRotation - C++");
+  app.setApplicationName(QString("MapRotation"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/MapRotation/main.cpp
+++ b/CppSamples/Maps/MapRotation/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("MapRotation - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/MapRotation/main.cpp
+++ b/CppSamples/Maps/MapRotation/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/MinMaxScale/main.cpp
+++ b/CppSamples/Maps/MinMaxScale/main.cpp
@@ -31,22 +31,30 @@ int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("MobileMap_SearchAndRoute - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
  // Initialize the sample

--- a/CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
+++ b/CppSamples/Maps/MobileMap_SearchAndRoute/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("MobileMap_SearchAndRoute - C++");
+  app.setApplicationName(QString("MobileMap_SearchAndRoute"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/OpenMapUrl/main.cpp
+++ b/CppSamples/Maps/OpenMapUrl/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/OpenMapUrl/main.cpp
+++ b/CppSamples/Maps/OpenMapUrl/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("OpenMapUrl - C++");
+  app.setApplicationName(QString("OpenMapUrl"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/OpenMapUrl/main.cpp
+++ b/CppSamples/Maps/OpenMapUrl/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenMapUrl - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("OpenMobileMap_MapPackage - C++");
+  app.setApplicationName(QString("OpenMobileMap_MapPackage"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
     return app.exec();
 }
-
-

--- a/CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
+++ b/CppSamples/Maps/OpenMobileMap_MapPackage/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenMobileMap_MapPackage - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Maps/ReadGeoPackage/main.cpp
+++ b/CppSamples/Maps/ReadGeoPackage/main.cpp
@@ -31,22 +31,30 @@ int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/SetInitialMapArea/main.cpp
+++ b/CppSamples/Maps/SetInitialMapArea/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SetInitialMapArea - C++");
+  app.setApplicationName(QString("SetInitialMapArea"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/SetInitialMapArea/main.cpp
+++ b/CppSamples/Maps/SetInitialMapArea/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/SetInitialMapArea/main.cpp
+++ b/CppSamples/Maps/SetInitialMapArea/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetInitialMapArea - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/CppSamples/Maps/SetInitialMapLocation/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SetInitialMapLocation - C++");
+  app.setApplicationName(QString("SetInitialMapLocation"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/CppSamples/Maps/SetInitialMapLocation/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetInitialMapLocation - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/CppSamples/Maps/SetInitialMapLocation/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/CppSamples/Maps/SetMapSpatialReference/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SetMapSpatialReference - C++");
+  app.setApplicationName(QString("SetMapSpatialReference"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/CppSamples/Maps/SetMapSpatialReference/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SetMapSpatialReference - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/CppSamples/Maps/SetMapSpatialReference/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/CppSamples/Maps/SetMaxExtent/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/CppSamples/Maps/SetMaxExtent/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("SetMaxExtent - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   SetMaxExtent::init();

--- a/CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/CppSamples/Maps/SetMaxExtent/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/CppSamples/Maps/SetMaxExtent/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Maps/SetMaxExtent/main.cpp
+++ b/CppSamples/Maps/SetMaxExtent/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("SetMaxExtent - C++"));
+  app.setApplicationName(QString("SetMaxExtent"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ShowDeviceLocationUsingIndoorPositioning - C++"));
+  app.setApplicationName(QString("ShowDeviceLocationUsingIndoorPositioning"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/main.cpp
@@ -31,10 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("ShowDeviceLocationUsingIndoorPositioning - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  // This sample does not use an API key
-  // const QString apiKey = QString("");
-  // setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   ShowDeviceLocationUsingIndoorPositioning::init();

--- a/CppSamples/Maps/ShowLocationHistory/main.cpp
+++ b/CppSamples/Maps/ShowLocationHistory/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ShowLocationHistory - C++"));
+  app.setApplicationName(QString("ShowLocationHistory"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ShowLocationHistory/main.cpp
+++ b/CppSamples/Maps/ShowLocationHistory/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ShowLocationHistory - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/ShowMagnifier/main.cpp
+++ b/CppSamples/Maps/ShowMagnifier/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ShowMagnifier - C++");
+  app.setApplicationName(QString("ShowMagnifier"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Maps/ShowMagnifier/main.cpp
+++ b/CppSamples/Maps/ShowMagnifier/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Maps/ShowMagnifier/main.cpp
+++ b/CppSamples/Maps/ShowMagnifier/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ShowMagnifier - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/TakeScreenshot/main.cpp
+++ b/CppSamples/Maps/TakeScreenshot/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("TakeScreenshot - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Maps/TakeScreenshot/main.cpp
+++ b/CppSamples/Maps/TakeScreenshot/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("TakeScreenshot - C++");
+  app.setApplicationName(QString("TakeScreenshot"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/ClosestFacility/main.cpp
+++ b/CppSamples/Routing/ClosestFacility/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ClosestFacility - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/ClosestFacility/main.cpp
+++ b/CppSamples/Routing/ClosestFacility/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ClosestFacility - C++");
+  app.setApplicationName(QString("ClosestFacility"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayRouteLayer - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DisplayRouteLayer::init();

--- a/CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DisplayRouteLayer - C++"));
+  app.setApplicationName(QString("DisplayRouteLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Routing/DisplayRouteLayer/main.cpp
+++ b/CppSamples/Routing/DisplayRouteLayer/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("FindClosestFacilityToMultipleIncidentsService - C++"));
+  app.setApplicationName(QString("FindClosestFacilityToMultipleIncidentsService"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
+++ b/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FindClosestFacilityToMultipleIncidentsService - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/FindRoute/main.cpp
+++ b/CppSamples/Routing/FindRoute/main.cpp
@@ -88,5 +88,3 @@ int main(int argc, char *argv[])
 
     return app.exec();
 }
-
-

--- a/CppSamples/Routing/FindRoute/main.cpp
+++ b/CppSamples/Routing/FindRoute/main.cpp
@@ -33,22 +33,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindRoute - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Routing/FindRoute/main.cpp
+++ b/CppSamples/Routing/FindRoute/main.cpp
@@ -31,7 +31,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FindRoute - C++");
+  app.setApplicationName(QString("FindRoute"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("FindServiceAreasForMultipleFacilities - C++"));
+  app.setApplicationName(QString("FindServiceAreasForMultipleFacilities"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
+++ b/CppSamples/Routing/FindServiceAreasForMultipleFacilities/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("FindServiceAreasForMultipleFacilities - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("NavigateARouteWithRerouting - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   NavigateARouteWithRerouting::init();

--- a/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("NavigateARouteWithRerouting - C++"));
+  app.setApplicationName(QString("NavigateARouteWithRerouting"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/NavigateRoute/main.cpp
+++ b/CppSamples/Routing/NavigateRoute/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("NavigateRoute - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/NavigateRoute/main.cpp
+++ b/CppSamples/Routing/NavigateRoute/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("NavigateRoute - C++"));
+  app.setApplicationName(QString("NavigateRoute"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/OfflineRouting/main.cpp
+++ b/CppSamples/Routing/OfflineRouting/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("OfflineRouting - C++"));
+  app.setApplicationName(QString("OfflineRouting"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/OfflineRouting/main.cpp
+++ b/CppSamples/Routing/OfflineRouting/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("OfflineRouting - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/CppSamples/Routing/RouteAroundBarriers/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("RouteAroundBarriers - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/RouteAroundBarriers/main.cpp
+++ b/CppSamples/Routing/RouteAroundBarriers/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("RouteAroundBarriers - C++"));
+  app.setApplicationName(QString("RouteAroundBarriers"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Routing/ServiceArea/main.cpp
+++ b/CppSamples/Routing/ServiceArea/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ServiceArea - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Routing/ServiceArea/main.cpp
+++ b/CppSamples/Routing/ServiceArea/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ServiceArea - C++");
+  app.setApplicationName(QString("ServiceArea"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/Add3DTilesLayer/main.cpp
+++ b/CppSamples/Scenes/Add3DTilesLayer/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)

--- a/CppSamples/Scenes/Add3DTilesLayer/main.cpp
+++ b/CppSamples/Scenes/Add3DTilesLayer/main.cpp
@@ -81,6 +81,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Scenes/Add3DTilesLayer/main.cpp
+++ b/CppSamples/Scenes/Add3DTilesLayer/main.cpp
@@ -82,35 +82,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Scenes/Add3DTilesLayer/main.cpp
+++ b/CppSamples/Scenes/Add3DTilesLayer/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("Add3DTilesLayer - C++"));
+  app.setApplicationName(QString("Add3DTilesLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/Add3DTilesLayer/main.cpp
+++ b/CppSamples/Scenes/Add3DTilesLayer/main.cpp
@@ -40,9 +40,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("Add3DTilesLayer - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   Add3DTilesLayer::init();

--- a/CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("AddAPointSceneLayer - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/AddAPointSceneLayer/main.cpp
+++ b/CppSamples/Scenes/AddAPointSceneLayer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("AddAPointSceneLayer - C++"));
+  app.setApplicationName(QString("AddAPointSceneLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("AddIntegratedMeshLayer - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
+++ b/CppSamples/Scenes/AddIntegratedMeshLayer/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("AddIntegratedMeshLayer - C++"));
+  app.setApplicationName(QString("AddIntegratedMeshLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/CppSamples/Scenes/Animate3DSymbols/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Animate3DSymbols - C++");
+  app.setApplicationName(QString("Animate3DSymbols"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/Animate3DSymbols/main.cpp
+++ b/CppSamples/Scenes/Animate3DSymbols/main.cpp
@@ -47,22 +47,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Animate3DSymbols - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("AnimateImagesWithImageOverlay - C++"));
+  app.setApplicationName(QString("AnimateImagesWithImageOverlay"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
+++ b/CppSamples/Scenes/AnimateImagesWithImageOverlay/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("AnimateImagesWithImageOverlay - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/CppSamples/Scenes/BasicSceneView/main.cpp
@@ -40,9 +40,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("BasicSceneView - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   BasicSceneView::init();

--- a/CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/CppSamples/Scenes/BasicSceneView/main.cpp
@@ -25,8 +25,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)

--- a/CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/CppSamples/Scenes/BasicSceneView/main.cpp
@@ -81,6 +81,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/CppSamples/Scenes/BasicSceneView/main.cpp
@@ -82,35 +82,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Scenes/BasicSceneView/main.cpp
+++ b/CppSamples/Scenes/BasicSceneView/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("BasicSceneView - C++"));
+  app.setApplicationName(QString("BasicSceneView"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ChangeAtmosphereEffect - C++"));
+  app.setApplicationName(QString("ChangeAtmosphereEffect"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
+++ b/CppSamples/Scenes/ChangeAtmosphereEffect/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ChangeAtmosphereEffect - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ChooseCameraController - C++"));
+  app.setApplicationName(QString("ChooseCameraController"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ChooseCameraController/main.cpp
+++ b/CppSamples/Scenes/ChooseCameraController/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ChooseCameraController - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("CreateTerrainSurfaceFromLocalRaster - C++"));
+  app.setApplicationName(QString("CreateTerrainSurfaceFromLocalRaster"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateTerrainSurfaceFromLocalRaster - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateTerrainSurfaceFromLocalTilePackage - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("CreateTerrainSurfaceFromLocalTilePackage - C++"));
+  app.setApplicationName(QString("CreateTerrainSurfaceFromLocalTilePackage"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/CppSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("Display3DLabelsInScene - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-    qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                  "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/Display3DLabelsInScene/main.cpp
+++ b/CppSamples/Scenes/Display3DLabelsInScene/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("Display3DLabelsInScene - C++"));
+  app.setApplicationName(QString("Display3DLabelsInScene"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -97,5 +97,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -42,22 +42,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("DisplaySceneLayer - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/DisplaySceneLayer/main.cpp
+++ b/CppSamples/Scenes/DisplaySceneLayer/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("DisplaySceneLayer - C++");
+  app.setApplicationName(QString("DisplaySceneLayer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -97,5 +97,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("DistanceCompositeSymbol - C++");
+  app.setApplicationName(QString("DistanceCompositeSymbol"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
+++ b/CppSamples/Scenes/DistanceCompositeSymbol/main.cpp
@@ -42,22 +42,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("DistanceCompositeSymbol - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("ExtrudeGraphics - C++");
+  app.setApplicationName(QString("ExtrudeGraphics"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -99,5 +99,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Scenes/ExtrudeGraphics/main.cpp
+++ b/CppSamples/Scenes/ExtrudeGraphics/main.cpp
@@ -44,22 +44,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("ExtrudeGraphics - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-    app.setApplicationName("FeatureLayerExtrusion - C++");
+    app.setApplicationName(QString("FeatureLayerExtrusion"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
+++ b/CppSamples/Scenes/FeatureLayerExtrusion/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
     app.setApplicationName("FeatureLayerExtrusion - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("FilterFeaturesInScene - C++"));
+  app.setApplicationName(QString("FilterFeaturesInScene"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
@@ -73,35 +73,5 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
 
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
 

--- a/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
@@ -72,6 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-
-

--- a/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
+++ b/CppSamples/Scenes/FilterFeaturesInScene/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("FilterFeaturesInScene - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   FilterFeaturesInScene::init();

--- a/CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("GetElevationAtPoint - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Scenes/GetElevationAtPoint/main.cpp
+++ b/CppSamples/Scenes/GetElevationAtPoint/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("GetElevationAtPoint - C++"));
+  app.setApplicationName(QString("GetElevationAtPoint"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/CppSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("OpenMobileScenePackage - C++"));
+  app.setApplicationName(QString("OpenMobileScenePackage"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/OpenMobileScenePackage/main.cpp
+++ b/CppSamples/Scenes/OpenMobileScenePackage/main.cpp
@@ -40,22 +40,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("OpenMobileScenePackage - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/OpenScene/main.cpp
+++ b/CppSamples/Scenes/OpenScene/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("OpenScene - C++");
+  app.setApplicationName(QString("OpenScene"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/OpenScene/main.cpp
+++ b/CppSamples/Scenes/OpenScene/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("OpenScene - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("OrbitCameraAroundObject - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
+++ b/CppSamples/Scenes/OrbitCameraAroundObject/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("OrbitCameraAroundObject - C++"));
+  app.setApplicationName(QString("OrbitCameraAroundObject"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -36,22 +36,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("RealisticLightingAndShadows - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
+++ b/CppSamples/Scenes/RealisticLightingAndShadows/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("RealisticLightingAndShadows - C++"));
+  app.setApplicationName(QString("RealisticLightingAndShadows"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/CppSamples/Scenes/SceneLayerSelection/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("SceneLayerSelection - C++"));
+  app.setApplicationName(QString("SceneLayerSelection"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/SceneLayerSelection/main.cpp
+++ b/CppSamples/Scenes/SceneLayerSelection/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("SceneLayerSelection - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ScenePropertiesExpressions - C++"));
+  app.setApplicationName(QString("ScenePropertiesExpressions"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
+++ b/CppSamples/Scenes/ScenePropertiesExpressions/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ScenePropertiesExpressions - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/SetSurfacePlacementMode/main.cpp
+++ b/CppSamples/Scenes/SetSurfacePlacementMode/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SurfacePlacement - C++");
+  app.setApplicationName(QString("SurfacePlacement"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/SetSurfacePlacementMode/main.cpp
+++ b/CppSamples/Scenes/SetSurfacePlacementMode/main.cpp
@@ -41,22 +41,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SurfacePlacement - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/Symbols/main.cpp
+++ b/CppSamples/Scenes/Symbols/main.cpp
@@ -97,5 +97,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Scenes/Symbols/main.cpp
+++ b/CppSamples/Scenes/Symbols/main.cpp
@@ -42,22 +42,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("Symbols - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/Symbols/main.cpp
+++ b/CppSamples/Scenes/Symbols/main.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName("Symbols - C++");
+  app.setApplicationName(QString("Symbols"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("SyncMapViewSceneView - C++"));
+  app.setApplicationName(QString("SyncMapViewSceneView"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/SyncMapViewSceneView/main.cpp
+++ b/CppSamples/Scenes/SyncMapViewSceneView/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("SyncMapViewSceneView - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/TerrainExaggeration/main.cpp
+++ b/CppSamples/Scenes/TerrainExaggeration/main.cpp
@@ -40,22 +40,30 @@ int main(int argc, char *argv[])
 
   QGuiApplication app(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   TerrainExaggeration::init();

--- a/CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ViewContentBeneathTerrainSurface - C++"));
+  app.setApplicationName(QString("ViewContentBeneathTerrainSurface"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
+++ b/CppSamples/Scenes/ViewContentBeneathTerrainSurface/main.cpp
@@ -39,22 +39,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ViewContentBeneathTerrainSurface - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 #endif
 
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ViewPointCloudDataOffline - C++"));
+  app.setApplicationName(QString("ViewPointCloudDataOffline"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
+++ b/CppSamples/Scenes/ViewPointCloudDataOffline/main.cpp
@@ -40,22 +40,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ViewPointCloudDataOffline - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Search/FindAddress/main.cpp
+++ b/CppSamples/Search/FindAddress/main.cpp
@@ -35,22 +35,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindAddress - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Search/FindAddress/main.cpp
+++ b/CppSamples/Search/FindAddress/main.cpp
@@ -92,5 +92,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-

--- a/CppSamples/Search/FindAddress/main.cpp
+++ b/CppSamples/Search/FindAddress/main.cpp
@@ -33,7 +33,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FindAddress - C++");
+  app.setApplicationName(QString("FindAddress"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Search/FindPlace/main.cpp
+++ b/CppSamples/Search/FindPlace/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("FindPlace - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
     // Initialize the sample

--- a/CppSamples/Search/FindPlace/main.cpp
+++ b/CppSamples/Search/FindPlace/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("FindPlace - C++");
+  app.setApplicationName(QString("FindPlace"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Search/OfflineGeocode/main.cpp
+++ b/CppSamples/Search/OfflineGeocode/main.cpp
@@ -32,7 +32,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("OfflineGeocode - C++");
+  app.setApplicationName(QString("OfflineGeocode"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Search/OfflineGeocode/main.cpp
+++ b/CppSamples/Search/OfflineGeocode/main.cpp
@@ -34,22 +34,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("OfflineGeocode - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/CppSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -29,22 +29,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ReverseGeocodeOnline - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Search/ReverseGeocodeOnline/main.cpp
+++ b/CppSamples/Search/ReverseGeocodeOnline/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ReverseGeocodeOnline - C++"));
+  app.setApplicationName(QString("ReverseGeocodeOnline"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -32,22 +32,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName("SearchDictionarySymbolStyle - C++");
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
+++ b/CppSamples/Search/SearchDictionarySymbolStyle/main.cpp
@@ -30,7 +30,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName("SearchDictionarySymbolStyle - C++");
+  app.setApplicationName(QString("SearchDictionarySymbolStyle"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("ConfigureSubnetworkTrace - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
+++ b/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("ConfigureSubnetworkTrace - C++"));
+  app.setApplicationName(QString("ConfigureSubnetworkTrace"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("CreateLoadReport - C++"));
+  app.setApplicationName(QString("CreateLoadReport"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
+++ b/CppSamples/UtilityNetwork/CreateLoadReport/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("CreateLoadReport - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -24,8 +24,6 @@
 #include <Windows.h>
 #endif
 
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -72,4 +72,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -73,36 +73,3 @@ int main(int argc, char *argv[])
   return app.exec();
 }
 
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
-

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -31,9 +31,31 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QString("DisplayContentOfUtilityNetworkContainer - C++"));
 
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   // Initialize the sample
   DisplayContentOfUtilityNetworkContainer::init();

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/main.cpp
@@ -27,7 +27,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("DisplayContentOfUtilityNetworkContainer - C++"));
+  app.setApplicationName(QString("DisplayContentOfUtilityNetworkContainer"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("DisplayUtilityAssociations - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
+++ b/CppSamples/UtilityNetwork/DisplayUtilityAssociations/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("DisplayUtilityAssociations - C++"));
+  app.setApplicationName(QString("DisplayUtilityAssociations"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -25,7 +25,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("PerformValveIsolationTrace - C++"));
+  app.setApplicationName(QString("PerformValveIsolationTrace"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("PerformValveIsolationTrace - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -30,22 +30,30 @@ int main(int argc, char *argv[])
   QGuiApplication app(argc, argv);
   app.setApplicationName(QStringLiteral("TraceUtilityNetwork - C++"));
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   // Initialize the sample

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/main.cpp
@@ -28,7 +28,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QStringLiteral("TraceUtilityNetwork - C++"));
+  app.setApplicationName(QString("TraceUtilityNetwork"));
 
   // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
   // requires an access token. For more information see

--- a/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/main.cpp
+++ b/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/main.cpp
@@ -24,7 +24,7 @@
 int main(int argc, char *argv[])
 {
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("ValidateUtilityNetworkTopology - C++"));
+  app.setApplicationName(QString("ValidateUtilityNetworkTopology"));
 
   // Initialize the sample
   ValidateUtilityNetworkTopology::init();

--- a/CppWidgetsSamples/DisplayInformation/BuildLegend/main.cpp
+++ b/CppWidgetsSamples/DisplayInformation/BuildLegend/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/DisplayInformation/GORenderers/main.cpp
+++ b/CppWidgetsSamples/DisplayInformation/GORenderers/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/DisplayInformation/GOSymbols/main.cpp
+++ b/CppWidgetsSamples/DisplayInformation/GOSymbols/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Layers/ArcGISTiledLayerUrl/main.cpp
+++ b/CppWidgetsSamples/Layers/ArcGISTiledLayerUrl/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/ChangeBasemap/main.cpp
+++ b/CppWidgetsSamples/Maps/ChangeBasemap/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/ChangeViewpoint/main.cpp
+++ b/CppWidgetsSamples/Maps/ChangeViewpoint/main.cpp
@@ -21,22 +21,30 @@ int main(int argc, char *argv[])
 {
   QApplication application(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
 

--- a/CppWidgetsSamples/Maps/DisplayMap/main.cpp
+++ b/CppWidgetsSamples/Maps/DisplayMap/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/ManageBookmarks/main.cpp
+++ b/CppWidgetsSamples/Maps/ManageBookmarks/main.cpp
@@ -21,22 +21,30 @@ int main(int argc, char *argv[])
 {
   QApplication application(argc, argv);
 
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   ManageBookmarks applicationWindow;

--- a/CppWidgetsSamples/Maps/MapLoaded/main.cpp
+++ b/CppWidgetsSamples/Maps/MapLoaded/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/MapRotation/main.cpp
+++ b/CppWidgetsSamples/Maps/MapRotation/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/OpenExistingMap/main.cpp
+++ b/CppWidgetsSamples/Maps/OpenExistingMap/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/SetInitialMapArea/main.cpp
+++ b/CppWidgetsSamples/Maps/SetInitialMapArea/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/SetInitialMapLocation/main.cpp
+++ b/CppWidgetsSamples/Maps/SetInitialMapLocation/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Maps/SetMapSpatialReference/main.cpp
+++ b/CppWidgetsSamples/Maps/SetMapSpatialReference/main.cpp
@@ -19,22 +19,30 @@
 
 int main(int argc, char *argv[])
 {
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/CppWidgetsSamples/Scenes/BasicSceneView/main.cpp
+++ b/CppWidgetsSamples/Scenes/BasicSceneView/main.cpp
@@ -27,22 +27,30 @@ int main(int argc, char *argv[])
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
 #endif
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: A permanent key that gives your application access to Esri
-  //    location services. Visit your ArcGIS Developers Dashboard create a new
-  //    API keys or access an existing API key.
-  const QString apiKey = QString("");
-  if (apiKey.isEmpty())
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
   {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
   }
   else
   {
-      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
   }
 
   QApplication application(argc, argv);

--- a/Templates/CppSampleTemplate/main.cpp.tmpl
+++ b/Templates/CppSampleTemplate/main.cpp.tmpl
@@ -29,10 +29,6 @@
 #include <Windows.h>
 #endif
 
-@if %{UseAPIKey}
-void setAPIKey(const QGuiApplication& app, QString apiKey);
-
-@endif
 int main(int argc, char *argv[])
 {
   @if %{ThreeDSample}
@@ -46,12 +42,34 @@ int main(int argc, char *argv[])
 
   @endif
   QGuiApplication app(argc, argv);
-  app.setApplicationName(QString("%{SampleName} - C++"));
+  app.setApplicationName(QString("%{SampleName}"));
 
   @if %{UseAPIKey}
-  // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-  const QString apiKey = QString("");
-  setAPIKey(app, apiKey);
+  // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+  // requires an access token. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
+
+  // The following methods grant an access token:
+
+  // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+  // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
+
+  // 2. API key authentication: Get a long-lived access token that gives your application access to
+  // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+  // Copy the API Key access token.
+
+  const QString accessToken = QString("");
+
+  if (accessToken.isEmpty())
+  {
+      qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                    "you to authenticate with an ArcGIS account or set the API Key property.";
+  }
+  else
+  {
+      Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+  }
 
   @endif
   // Initialize the sample
@@ -71,38 +89,3 @@ int main(int argc, char *argv[])
 
   return app.exec();
 }
-
-@if %{UseAPIKey}
-// Use of Esri location services, including basemaps and geocoding,
-// requires authentication using either an ArcGIS identity or an API Key.
-// 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-//    organization in ArcGIS Online or ArcGIS Enterprise.
-// 2. API key: API key: a permanent key that grants access to
-//    location services and premium content in your applications.
-//    Visit your ArcGIS Developers Dashboard to create a new
-//    API key or access an existing API key.
-
-void setAPIKey(const QGuiApplication& app, QString apiKey)
-{
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
-
-@endif

--- a/Templates/CppWidgetsSampleTemplate/main.cpp.tmpl
+++ b/Templates/CppWidgetsSampleTemplate/main.cpp.tmpl
@@ -43,9 +43,31 @@ int main(int argc, char *argv[])
     QApplication application(argc, argv);
 
     @if %{UseAPIKey}
-    // Access to Esri location services requires an API key. This can be copied below or used as a command line argument.
-    const QString apiKey = QString("");
-    setAPIKey(application, apiKey);
+    // Use of ArcGIS location services, such as basemap styles, geocoding, and routing services,
+    // requires an access token. For more information see
+    // https://links.esri.com/arcgis-runtime-security-auth.
+
+    // The following methods grant an access token:
+
+    // 1. User authentication: Grants a temporary access token associated with a user's ArcGIS account.
+    // To generate a token, a user logs in to the app with an ArcGIS account that is part of an
+    // organization in ArcGIS Online or ArcGIS Enterprise.
+
+    // 2. API key authentication: Get a long-lived access token that gives your application access to
+    // ArcGIS location services. Go to the tutorial at https://links.esri.com/create-an-api-key.
+    // Copy the API Key access token.
+
+    const QString accessToken = QString("");
+
+    if (accessToken.isEmpty())
+    {
+        qWarning() << "Use of ArcGIS location services, such as the basemap styles service, requires" <<
+                      "you to authenticate with an ArcGIS account or set the API Key property.";
+    }
+    else
+    {
+        Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(accessToken);
+    }
 
     @endif
     %{SampleName} applicationWindow;
@@ -55,36 +77,3 @@ int main(int argc, char *argv[])
 
     return application.exec();
 }
-
-@if %{UseAPIKey}
-void setAPIKey(const QApplication& app, QString apiKey)
-{
-  // Use of Esri location services, including basemaps and geocoding,
-  // requires authentication using either an ArcGIS identity or an API Key.
-  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-  //    organization in ArcGIS Online or ArcGIS Enterprise.
-  // 2. API key: API key: a permanent key that grants access to
-  //    location services and premium content in your applications.
-  //    Visit your ArcGIS Developers Dashboard to create a new
-  //    API key or access an existing API key.
-  if (apiKey.isEmpty())
-  {
-    // Try parsing API key from command line argument, which uses the following syntax "-k <apiKey>".
-    QCommandLineParser cmdParser;
-    QCommandLineOption apiKeyArgument(QStringList{"k", "api"}, "The API Key property used to access Esri location services", "apiKeyInput");
-    cmdParser.addOption(apiKeyArgument);
-    cmdParser.process(app);
-
-    apiKey = cmdParser.value(apiKeyArgument);
-
-    if (apiKey.isEmpty())
-    {
-      qWarning() << "Use of Esri location services, including basemaps, requires" <<
-                    "you to authenticate with an ArcGIS identity or set the API Key property.";
-      return;
-    }
-  }
-
-  Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-}
-@endif


### PR DESCRIPTION
# Description

update apikey terminology to use access token instead. Also renamed samples when being run standalone to not have ` - C++` included in it's name.

Also caught a few main signatures that deviated from the rest. Updated them so it's unified.

since i modified main.cpp files of individual samples, I picked 1/2 from each category and built them standalone and ran into no issues. Testing all 220 I think is unnecessary as the changes are all the same.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [x] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
