### PR TITLE
I think this is it?

### DIFF
--- a/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
+++ b/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/FilterByDefinitionExpressionOrDisplayFilter.cpp
@@ -104,7 +104,9 @@ int FilterByDefinitionExpressionOrDisplayFilter::currentFeatureCount() const
 
 void FilterByDefinitionExpressionOrDisplayFilter::setDefExpression(const QString& whereClause)
 {
-  // In QML, "req_type = \'Tree Maintenance or Damage\'"
+  // reset display filter parameters before setting definition expression parameters
+  resetDisplayFilterParams();
+
   m_featureLayer->setDefinitionExpression(whereClause);
 
   // Feature count in the extent should not change with different definition expressions.
@@ -115,6 +117,9 @@ void FilterByDefinitionExpressionOrDisplayFilter::setDefExpression(const QString
 
 void FilterByDefinitionExpressionOrDisplayFilter::setDisplayFilter(const QString& whereClause)
 {
+  // reset definition expression parameters before setting display filter parameters
+  resetDefExpressionParams();
+
   DisplayFilter* displayFilter = new DisplayFilter("Damaged Trees", whereClause, this);
   const QList<DisplayFilter*> availableFilters{displayFilter};
 


### PR DESCRIPTION
# Description

Two separate reset functions already existed so I just executed those prior to applying the filters.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
