### PR TITLE
updating samples with reticle

### DIFF
--- a/CppSamples/EditData/SnapGeometryEdits/README.md
+++ b/CppSamples/EditData/SnapGeometryEdits/README.md
@@ -55,7 +55,7 @@ Snapping is used to maintain data integrity between different sources of data wh
 
 To snap to polygon and polyline layers, the recommended approach is to set the `FeatureLayer`'s feature tiling mode to `FeatureTilingMode::EnabledWithFullResolutionWhenSupported` and use the default `ServiceFeatureTable` feature request mode `FeatureRequestMode::OnInteractionCache`. Local data sources, such as geodatabases, always provide full resolution geometries. Point and multipoint feature layers are also always full resolution.
 
-Snapping can be used during interactive edits that move existing vertices using the `VertexTool`. It is also supported for adding new vertices for input devices with a hover event (such as a mouse move without a mouse button press). Using the magnifier to perform a vertex move allows users of touch devices to clearly see the visual cues for snapping.
+Snapping can be used during interactive edits that move existing vertices using the `VertexTool` or `ReticleVertexTool`. When adding new vertices, snapping also works with a hover event (such as a mouse move without a mouse button press). Using the `ReticleVertexTool` to add and move vertices allows users of touch screen devices to clearly see the visual cues for snapping.
 
 ## Tags
 

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
@@ -39,6 +39,7 @@
 #include "MapTypes.h"
 #include "Portal.h"
 #include "PortalItem.h"
+#include "ReticleVertexTool.h"
 #include "SimpleFillSymbol.h"
 #include "SimpleLineSymbol.h"
 #include "SimpleMarkerSymbol.h"
@@ -50,6 +51,7 @@
 #include "SnapSourceListModel.h"
 
 #include <QFuture>
+#include <QtCore/qglobal.h>
 
 using namespace Esri::ArcGISRuntime;
 
@@ -62,6 +64,12 @@ SnapGeometryEdits::SnapGeometryEdits(QObject* parent /* = nullptr */) :
 
   m_geometryEditor = new GeometryEditor(this);
   m_graphicsOverlay = new GraphicsOverlay(this);
+
+  // if mobile, use ReticleVertexTool
+  #if defined(Q_OS_IOS) || defined(Q_OS_ANDROID)
+    m_geometryEditor->setTool(new ReticleVertexTool(this));
+  #endif // defined(Q_OS_IOS) || defined(Q_OS_ANDROID)
+
   connect (m_map, &Map::doneLoading, this, [this]()
   {
     for (Layer* layer : *m_map->operationalLayers())
@@ -108,8 +116,7 @@ void SnapGeometryEdits::setMapView(MapQuickView* mapView)
   m_mapView->graphicsOverlays()->append(m_graphicsOverlay);
 
   // Set the geometry editor on the map view
-  m_mapView->setGeometryEditor(m_geometryEditor);
-  m_mapView->setMagnifierEnabled(true);
+  m_mapView->setGeometryEditor(m_geometryEditor);  
 
   emit mapViewChanged();
   createInitialSymbols();

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
@@ -51,7 +51,7 @@
 #include "SnapSourceListModel.h"
 
 #include <QFuture>
-#include <QtCore/qglobal.h>
+#include <QtGlobal>
 
 using namespace Esri::ArcGISRuntime;
 

--- a/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.cpp
+++ b/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.cpp
@@ -42,6 +42,7 @@
 #include "PolygonBuilder.h"
 #include "Polyline.h"
 #include "PolylineBuilder.h"
+#include "ReticleVertexTool.h"
 #include "ShapeTool.h"
 #include "SimpleFillSymbol.h"
 #include "SimpleLineSymbol.h"
@@ -70,6 +71,7 @@ CreateAndEditGeometries::CreateAndEditGeometries(QObject* parent /* = nullptr */
   m_ellipseTool = ShapeTool::create(ShapeToolType::Ellipse, this);
   m_rectangleTool = ShapeTool::create(ShapeToolType::Rectangle, this);
   m_triangleTool = ShapeTool::create(ShapeToolType::Triangle, this);
+  m_reticleTool = new ReticleVertexTool(this);
 }
 
 CreateAndEditGeometries::~CreateAndEditGeometries() = default;
@@ -220,6 +222,9 @@ void CreateAndEditGeometries::setTool(GeometryEditorToolType toolType)
     case GeometryEditorToolType::Triangle:
       m_geometryEditor->setTool(m_triangleTool);
       break;
+
+    case GeometryEditorToolType::Reticle:
+      m_geometryEditor->setTool(m_reticleTool);
 
     default:
       break;

--- a/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.h
+++ b/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.h
@@ -30,6 +30,7 @@ namespace Esri::ArcGISRuntime
   class SimpleLineSymbol;
   class SimpleFillSymbol;
   class VertexTool;
+  class ReticleVertexTool;
 }
 
 #include <QObject>
@@ -72,7 +73,8 @@ public:
     Arrow,
     Ellipse,
     Rectangle,
-    Triangle
+    Triangle,
+    Reticle
   };
 
   Q_ENUM(GeometryEditorToolType)
@@ -126,6 +128,7 @@ private:
   Esri::ArcGISRuntime::ShapeTool* m_ellipseTool = nullptr;
   Esri::ArcGISRuntime::ShapeTool* m_rectangleTool = nullptr;
   Esri::ArcGISRuntime::ShapeTool* m_triangleTool = nullptr;
+  Esri::ArcGISRuntime::ReticleVertexTool* m_reticleTool = nullptr;
 
   QObject* m_tempGraphicsParent = nullptr;
 };

--- a/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml
+++ b/CppSamples/Geometry/CreateAndEditGeometries/CreateAndEditGeometries.qml
@@ -138,7 +138,8 @@ Item {
 
                 ComboBox {
                     id: toolCombo
-                    model: [qsTr("Vertex Tool"), qsTr("Freehand Tool"), qsTr("Arrow Shape Tool"), qsTr("Ellipse Shape Tool"), qsTr("Rectangle Shape Tool"), qsTr("Triangle Shape Tool")]
+                    model: [qsTr("Vertex Tool"), qsTr("Freehand Tool"), qsTr("Arrow Shape Tool"), qsTr("Ellipse Shape Tool"),
+                           ("Rectangle Shape Tool"), qsTr("Triangle Shape Tool"), qsTr("Reticle Tool")]
                     Layout.columnSpan: 2
                     Layout.fillWidth: true
 
@@ -170,6 +171,9 @@ Item {
                             break;
                         case 5: // ShapeTool with triangle shape type
                             model.setTool(CreateAndEditGeometriesSample.Triangle);
+                            break;
+                        case 6: // Reticle Vertex Tool
+                            model.setTool(CreateAndEditGeometriesSample.Reticle);
                             break;
                         default:
                             model.setTool(CreateAndEditGeometriesSample.Vertex);

--- a/CppSamples/Geometry/CreateAndEditGeometries/README.md
+++ b/CppSamples/Geometry/CreateAndEditGeometries/README.md
@@ -12,11 +12,13 @@ A field worker can mark features of interest on a map using an appropriate geome
 
 To create a new geometry, press the button appropriate for the geometry type you want to create (i.e. points, multipoints, polyline, or polygon) and interactively tap and drag on the map view to create the geometry.
 
-To edit an existing geometry, tap the geometry to be edited in the map to select it and then edit the geometry by tapping and dragging elements of the geometry.
+To edit an existing geometry, tap the geometry to be edited in the map and then perform edits by tapping and dragging its elements.
 
 When the whole geometry is selected, you can use the control handles to scale and rotate the geometry.
 
-If creating or editing polyline or polygon geometries, choose the desired creation/editing tool from the combo box.
+If creating or editing polyline or polygon geometries, choose the desired creation/editing tool (i.e. `VertexTool`, `ReticleVertexTool`, `FreehandTool`, or one of the available `ShapeTool`s).
+
+When using the `ReticleVertexTool`, you can move the map position of the reticle by dragging and zooming the map. Insert a vertex under the reticle by tapping on the map. Move a vertex by tapping when the reticle is located over a vertex, drag the map to move the position of the reticle, then tap a second time to place the vertex.
 
 Use the control panel to undo or redo changes made to the geometry, delete a selected element, save the geometry, stop the editing session and discard any edits, and remove all geometries from the map.
 
@@ -30,7 +32,7 @@ Use the control panel to undo or redo changes made to the geometry, delete a sel
         - Find the desired graphic in the `IdentifyGraphicsOverlayResult::graphics()` list.
         - Access the geometry associated with the `Graphic` using `Graphic::geometry()` - this will be used in the `GeometryEditor::start(Geometry)` method.
 
-3. Create `VertexTool`,  `FreehandTool`, or `ShapeTool` objects which define how the user interacts with the view to create or edit geometries, using `GeometryEditor::setTool(GeometryEditorTool)`.
+3. Create `VertexTool`, `ReticleVertexTool`, `FreehandTool`, or `ShapeTool` objects which define how the user interacts with the view to create or edit geometries, and set the geometry editor tool using `GeometryEditor::setTool(GeometryEditorTool)`.
 4. Edit a tool's `InteractionConfiguration` to set the `GeometryEditorScaleMode` to allow either uniform or stretch scale mode.
 5. Check to see if undo and redo are possible during an editing session using `GeometryEditor::canUndo()` and `GeometryEditor::canRedo()`. If it's possible, use `GeometryEditor::undo()` and `GeometryEditor::redo()`.
 6. Check whether the currently selected `GeometryEditorElement` can be deleted (`GeometryEditor::selectedElement::canDelete()`). If the element can be deleted, delete using `GeometryEditor::deleteSelectedElement()`.


### PR DESCRIPTION
# Description

Updates to the GE samples to use Reticle. For the snapping sample, use the Reticle on mobile only.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
