### PR TITLE
Bri12415/display device perm check

### DIFF
--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
@@ -74,6 +74,8 @@ void DisplayDeviceLocation::componentComplete()
 void DisplayDeviceLocation::startLocationDisplay()
 {
   QLocationPermission locationPermission{};
+  locationPermission.setAccuracy(QLocationPermission::Accuracy::Precise);
+  locationPermission.setAvailability(QLocationPermission::Availability::WhenInUse);
   switch (qApp->checkPermission(locationPermission))
   {
   case Qt::PermissionStatus::Undetermined:

--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
@@ -27,7 +27,10 @@
 #include "MapViewTypes.h"
 #include "LocationDisplay.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)) || defined(Q_OS_IOS) || defined(Q_OS_MACOS) || defined(Q_OS_ANDROID)
+#define PERMISSIONS_PLATFORM
 #include <QPermissions>
+#endif
 
 using namespace Esri::ArcGISRuntime;
 
@@ -73,6 +76,8 @@ void DisplayDeviceLocation::componentComplete()
 
 void DisplayDeviceLocation::startLocationDisplay()
 {
+  // https://bugreports.qt.io/browse/QTBUG-116178
+#ifdef PERMISSIONS_PLATFORM
   QLocationPermission locationPermission{};
   locationPermission.setAccuracy(QLocationPermission::Accuracy::Precise);
   locationPermission.setAvailability(QLocationPermission::Availability::WhenInUse);
@@ -91,6 +96,9 @@ void DisplayDeviceLocation::startLocationDisplay()
     emit locationPermissionDenied();
     return;
   }
+#else
+  m_mapView->locationDisplay()->start();
+#endif
 }
 
 void DisplayDeviceLocation::stopLocationDisplay()

--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
@@ -27,7 +27,7 @@
 #include "MapViewTypes.h"
 #include "LocationDisplay.h"
 
-#include <QPermission>
+#include <QPermissions>
 
 using namespace Esri::ArcGISRuntime;
 

--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.h
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.h
@@ -54,6 +54,8 @@ signals:
   void stopModeChanged();
   void closeModeChanged();
 
+  void locationPermissionDenied();
+
 private:
   static const QString compassMode();
   static const QString navigationMode();

--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.qml
@@ -16,6 +16,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Dialogs
 import Esri.Samples
 
 DisplayDeviceLocationSample {
@@ -169,6 +170,27 @@ DisplayDeviceLocationSample {
                     autoPanListView.visible = true;
                 }
             }
+        }
+    }
+
+    Connections {
+        target: deviceLocationSample
+        function onLocationPermissionDenied() {
+            permissionDeniedDialog.open()
+        }
+    }
+
+    Dialog {
+        id: permissionDeniedDialog
+        title: "Location Permission Denied"
+        modal: true
+        standardButtons: Dialog.Ok
+        x: (parent.width - width) / 2
+        y: (parent.height - height) / 2
+
+        Text {
+            text: "This application requires location permissions."
+            color: "white"
         }
     }
 }

--- a/CppSamples/Maps/DisplayDeviceLocation/Info.plist
+++ b/CppSamples/Maps/DisplayDeviceLocation/Info.plist
@@ -30,8 +30,6 @@
 	<string>NO</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-        <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-        <string>Location required for application</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
         <string>Location required for application</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/CppSamples/Maps/DisplayDeviceLocation/Info.plist
+++ b/CppSamples/Maps/DisplayDeviceLocation/Info.plist
@@ -30,10 +30,10 @@
 	<string>NO</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSLocationAlwaysUsageDescription</key>
-	<string></string>
+        <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+        <string>Location required for application</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+        <string>Location required for application</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
# Description

Showcase an example of users explicitly requesting permissions with Qt's QPermission API


![Screenshot 2024-07-17 at 2 25 28 PM](https://github.com/user-attachments/assets/413952bc-f2ae-4a96-8c10-d6377fc9f41c) Triggered permissions check

![Screenshot 2024-07-17 at 2 25 44 PM](https://github.com/user-attachments/assets/e7c880b1-5494-4649-967e-218159a6ad61) If granted

![Screenshot 2024-07-17 at 2 26 03 PM](https://github.com/user-attachments/assets/9cd32136-d68d-4bc2-bbdc-73fce9c192d7) If denied

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [ ] macOS
- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
