### PR TITLE
James/restore ls samples

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -139,7 +139,7 @@ void SampleManager::setDownloadFailed(bool didFail)
 // Build the Categories List
 void SampleManager::buildCategoriesList()
 {
-  QDir dir(DIRNAMESAMPLES);
+  const QDir dir(DIRNAMESAMPLES);
   QFile xmlFile(":/Samples/Categories.xml");
 
   // Go through the XML to find the sample categories
@@ -148,16 +148,16 @@ void SampleManager::buildCategoriesList()
     xmlFile.open(QIODevice::ReadOnly);
     QDomDocument doc;
     doc.setContent(&xmlFile);
-    QDomNodeList fileList = doc.documentElement().elementsByTagName("category");
+    const QDomNodeList fileList = doc.documentElement().elementsByTagName("category");
 
     for (int i = 0; i < fileList.count(); i++)
     {
       // The first node contains the name
-      QDomNode node = fileList.at(i).childNodes().at(0);
-      QString name = node.toElement().text();
+      const QDomNode node = fileList.at(i).childNodes().at(0);
+      const QString name = node.toElement().text();
       // The second node contains the display name
-      QDomNode nameNode = fileList.at(i).childNodes().at(1);
-      QString displayName = nameNode.toElement().text();
+      const QDomNode nameNode = fileList.at(i).childNodes().at(1);
+      const QString displayName = nameNode.toElement().text();
       appendCategoryToManager(createCategory(name, displayName, dir));
     }
   }
@@ -169,7 +169,6 @@ void SampleManager::buildCategoriesList()
 #ifdef LOCALSERVER_SUPPORTED
   if (LocalServer::isInstallValid())
   {
-    const QDir dir(DIRNAMESAMPLES);
     appendCategoryToManager(createCategory("LocalServer", "Local Server", dir));
   }
 #endif // LOCALSERVER_SUPPORTED

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -64,7 +64,7 @@ using namespace Esri::ArcGISRuntime;
 
 #ifdef LOCALSERVER_SUPPORTED
 #include "LocalServer.h"
-#endif
+#endif // LOCALSERVER_SUPPORTED
 
 #define STRINGIZE(x) #x
 #define QUOTE(x) STRINGIZE(x)
@@ -81,7 +81,7 @@ SampleManager::SampleManager(QObject *parent):
 {
 #ifdef LOCALSERVER_SUPPORTED
   createAndSetTempDirForLocalServer();
-#endif
+#endif // LOCALSERVER_SUPPORTED
 
   if (QNetworkInformation::loadBackendByFeatures(QNetworkInformation::Feature::Reachability))
   {
@@ -122,7 +122,7 @@ void SampleManager::createAndSetTempDirForLocalServer()
   // set the temp & app data path for the local server
   LocalServer::setTempDataPath(m_tempDir->path());
   LocalServer::setAppDataPath(m_tempDir->path());
-#endif
+#endif // LOCALSERVER_SUPPORTED
 }
 
 void SampleManager::setCancelDownload(bool cancel)
@@ -165,6 +165,14 @@ void SampleManager::buildCategoriesList()
   {
     qWarning() << "could not find Categories.xml";
   }
+
+#ifdef LOCALSERVER_SUPPORTED
+  if (LocalServer::isInstallValid())
+  {
+    const QDir dir(DIRNAMESAMPLES);
+    appendCategoryToManager(createCategory("LocalServer", "Local Server", dir));
+  }
+#endif // LOCALSERVER_SUPPORTED
 }
 
 SampleCategory* SampleManager::createCategory(const QString& name, const QString& displayName, const QDir& dir)

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -67,7 +67,7 @@ public:
   explicit SampleManager(QObject* parent = nullptr);
   ~SampleManager() override;
 
-  Q_INVOKABLE virtual void init();
+  Q_INVOKABLE void init();
 
   Q_INVOKABLE bool dataItemsExists();
   Q_INVOKABLE void clearCredentialCache();
@@ -118,7 +118,7 @@ signals:
 
 protected:
   void setDownloadProgress(double progress);
-  virtual void buildCategoriesList();
+  void buildCategoriesList();
   SampleCategory* createCategory(const QString& name, const QString& displayName, const QDir& dir);
   bool appendCategoryToManager(SampleCategory* category);
 


### PR DESCRIPTION
# Description

Add LocalServer category back to the sample viewer for Windows and Linux, if and only if local server is installed on the machine it's running on.

This logic was lost in the porting. There is no more `CppSampleManager` class, so I removed `virtual` to make it clearer there's no more overrides. 
https://github.com/Esri/arcgis-maps-sdk-samples-qt/blob/6d49d3fce7f8b89d72da7589aacd22c90d91f773/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/CppSampleManager.cpp#L66-L77

## Type of change

- [x] Bug fix

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [x] Linux
- [ ] macOS
- [ ] iOS

