### PR TITLE
James/task manager

### DIFF
--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -257,12 +257,10 @@ void PerformValveIsolationTrace::performTrace()
       traceParameters->traceConfiguration()->filter()->setBarriers(categoryComparison);
     }
 
-    m_taskCanceler->addTask(
-      m_utilityNetwork->traceAsync(traceParameters).then(this, [this](QList<UtilityTraceResult*>)
-      {
-        onTraceCompleted_();
-      })
-    );
+    m_taskCanceler->addTask(m_utilityNetwork->traceAsync(traceParameters).then(this, [this](QList<UtilityTraceResult*>)
+    {
+      onTraceCompleted_();
+    }));
   }
 }
 

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -69,6 +69,9 @@
 #include <QFuture>
 #include <QUuid>
 
+// Other headers
+#include "TaskCanceler.h"
+
 using namespace Esri::ArcGISRuntime;
 
 namespace
@@ -103,7 +106,8 @@ PerformValveIsolationTrace::PerformValveIsolationTrace(QObject* parent /* = null
   m_startingLocationOverlay(new GraphicsOverlay(this)),
   m_filterBarriersOverlay(new GraphicsOverlay(this)),
   m_serviceGeodatabase(new ServiceGeodatabase(featureServiceUrl, m_cred, this)),
-  m_graphicParent(new QObject())
+  m_graphicParent(new QObject()),
+  m_taskCanceler(std::make_unique<TaskCanceler>())
 {
   // disable UI while loading service geodatabase and utility network
   m_tasksRunning = true;
@@ -174,11 +178,12 @@ void PerformValveIsolationTrace::setMapView(MapQuickView* mapView)
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
     m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
-    m_mapView->identifyLayersAsync(mouseEvent.position(), tolerance, returnPopups).then(this, [this](const QList<IdentifyLayerResult*>& results)
+    auto f = m_mapView->identifyLayersAsync(mouseEvent.position(), tolerance, returnPopups).then(this, [this](const QList<IdentifyLayerResult*>& results)
     {
       // handle the identify results
       onIdentifyLayersCompleted_(results);
     });
+    m_taskCanceler->addTask(f);
   });
 
   // apply renderers
@@ -252,10 +257,13 @@ void PerformValveIsolationTrace::performTrace()
       UtilityCategoryComparison* categoryComparison = new UtilityCategoryComparison(selectedCategory, UtilityCategoryComparisonOperator::Exists, this);
       traceParameters->traceConfiguration()->filter()->setBarriers(categoryComparison);
     }
-    m_utilityNetwork->traceAsync(traceParameters).then(this, [this](QList<UtilityTraceResult*>)
-    {
-      onTraceCompleted_();
-    });
+
+    m_taskCanceler->addTask(
+      m_utilityNetwork->traceAsync(traceParameters).then(this, [this](QList<UtilityTraceResult*>)
+      {
+        onTraceCompleted_();
+      })
+    );
   }
 }
 
@@ -313,7 +321,7 @@ void PerformValveIsolationTrace::onTraceCompleted_()
         }
         queryParameters.setObjectIds(objectIds);
         auto future = featureLayer->selectFeaturesAsync(queryParameters, SelectionMode::New);
-        Q_UNUSED(future)
+        m_taskCanceler->addTask(future);
       }
     }
   }
@@ -388,7 +396,7 @@ void PerformValveIsolationTrace::connectSignals()
       return;
 
     // display starting location
-    m_utilityNetwork->featuresForElementsAsync(QList<UtilityElement*> {m_startingLocation}).then(this, [this](QList<ArcGISFeature*>)
+    auto f = m_utilityNetwork->featuresForElementsAsync(QList<UtilityElement*> {m_startingLocation}).then(this, [this](QList<ArcGISFeature*>)
     {
       // display starting location
       ArcGISFeatureListModel* elementFeaturesList = m_utilityNetwork->featuresForElementsResult();
@@ -397,10 +405,11 @@ void PerformValveIsolationTrace::connectSignals()
       m_startingLocationOverlay->graphics()->append(graphic);
 
       constexpr double scale = 3000.0;
-      m_mapView->setViewpointCenterAsync(startingLocationGeometry, scale);
+      m_taskCanceler->addTask(m_mapView->setViewpointCenterAsync(startingLocationGeometry, scale));
       m_tasksRunning = false;
       emit tasksRunningChanged();
     });
+    m_taskCanceler->addTask(f);
 
     // populate the combo box choices
     m_categoriesList = categoriesList();

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.h
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.h
@@ -44,6 +44,8 @@ class ServiceGeodatabase;
 Q_MOC_INCLUDE("MapQuickView.h")
 Q_MOC_INCLUDE("IdentifyLayerResult.h")
 
+class TaskCanceler;
+
 class PerformValveIsolationTrace : public QObject
 {
   Q_OBJECT
@@ -99,6 +101,7 @@ private:
   QStringList m_terminals;
   QScopedPointer<QObject> m_graphicParent;
   QStringList m_categoriesList;
+  std::unique_ptr<TaskCanceler> m_taskCanceler;
   int m_selectedIndex = -1;
   bool m_isolateFeatures = false;
   bool m_tasksRunning = false;

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.pro
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.pro
@@ -32,8 +32,11 @@ include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------
 
+INCLUDEPATH += $${PWD}/../../../SampleViewer
+
 HEADERS += \
-    PerformValveIsolationTrace.h
+    PerformValveIsolationTrace.h \
+    $${PWD}/../../../SampleViewer/TaskCanceler.h
 
 SOURCES += \
     main.cpp \

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -190,11 +190,10 @@ void TraceUtilityNetwork::connectSignals()
     constexpr double tolerance = 10.0;
     constexpr bool returnPopups = false;
     m_clickPoint = m_mapView->screenToLocation(mouseEvent.position().x(), mouseEvent.position().y());
-    auto f = m_mapView->identifyLayersAsync(mouseEvent.position(), tolerance, returnPopups).then(this, [this](const QList<IdentifyLayerResult*>& results)
+    m_taskCanceler->addTask(m_mapView->identifyLayersAsync(mouseEvent.position(), tolerance, returnPopups).then(this, [this](const QList<IdentifyLayerResult*>& results)
     {
       onIdentifyLayersCompleted_(results);
-    });
-    m_taskCanceler->addTask(f);
+    }));
   });
 }
 
@@ -282,14 +281,13 @@ void TraceUtilityNetwork::trace(int index)
   m_traceParams->setStartingLocations(m_startingLocations);
   m_traceParams->setBarriers(m_barriers);
   // Perform a connected trace on the utility network
-  auto f = m_utilityNetwork->traceAsync(m_traceParams).then(this, [this](QList<UtilityTraceResult*>)
+  m_taskCanceler->addTask(m_utilityNetwork->traceAsync(m_traceParams).then(this, [this](QList<UtilityTraceResult*>)
   {
     onTraceCompleted_();
   }).onFailed([this](const ErrorException& exception)
   {
     onTaskFailed_(exception);
-  });
-  m_taskCanceler->addTask(f);
+  }));
 }
 
 void TraceUtilityNetwork::reset()

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.h
@@ -54,6 +54,8 @@ class UtilityTraceParameters;
 Q_MOC_INCLUDE("MapQuickView.h")
 Q_MOC_INCLUDE("IdentifyLayerResult.h")
 
+class TaskCanceler;
+
 class TraceUtilityNetwork : public QObject
 {
   Q_OBJECT
@@ -135,7 +137,7 @@ private:
   QList<Esri::ArcGISRuntime::UtilityElement*> m_barriers;
   QList<Esri::ArcGISRuntime::UtilityTerminal*> m_terminals;
   QScopedPointer<QObject> m_graphicParent;
-
+  std::unique_ptr<TaskCanceler> m_taskCanceler;
 };
 
 #endif // TraceUtilityNetwork_H

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.pro
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.pro
@@ -32,8 +32,11 @@ include($$PWD/arcgisruntime.pri)
 
 #-------------------------------------------------------------------------------
 
+INCLUDEPATH += $${PWD}/../../../SampleViewer
+
 HEADERS += \
-    TraceUtilityNetwork.h
+    TraceUtilityNetwork.h \
+    $${PWD}/../../../SampleViewer/TaskCanceler.h
 
 SOURCES += \
     main.cpp \

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -164,7 +164,8 @@ HEADERS += \
     $$COMMONVIEWER/SearchFilterSimpleKeywordCriteria.h \
     $$COMMONVIEWER/SourceCode.h \
     $$COMMONVIEWER/SourceCodeListModel.h \
-    $$COMMONVIEWER/ZipHelper.h
+    $$COMMONVIEWER/ZipHelper.h \
+    $$COMMONVIEWER/TaskCanceler.h
 
 SOURCES += \
     $$COMMONVIEWER/SyntaxHighlighter/syntax_highlighter.cpp \

--- a/SampleViewer/TaskCanceler.h
+++ b/SampleViewer/TaskCanceler.h
@@ -1,0 +1,76 @@
+// [Legal]
+// Copyright 2024 Esri.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// [Legal]
+
+#ifndef TaskCanceler_H
+#define TaskCanceler_H
+
+// Qt headers
+#include <QFutureWatcher>
+#include <QDebug>
+
+#include <memory>
+#include <mutex>
+#include <unordered_set>
+
+// This class is a helper to ensure any QFuture-based async tasks are
+// canceled upon destruction. This is useful to ensure
+// callbacks aren't being executed at the same time as samples are being
+// shut down
+
+class TaskCanceler
+{
+public:
+  TaskCanceler() = default;
+  ~TaskCanceler()
+  {
+    cancelAllTasks_();
+  }
+
+  template <typename T>
+  void addTask(const QFuture<T>& future)
+  {
+    auto watcher = std::make_shared<QFutureWatcher<T>>();
+
+    QObject::connect(watcher.get(), &QFutureWatcher<T>::finished, &m_connectionContext, [this, watcher]()
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_watchers.erase(watcher);
+    });
+    watcher->setFuture(future);
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_watchers.insert(watcher);
+  }
+
+private:
+  void cancelAllTasks_()
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    qDebug() << QString("canceling %1 tasks").arg(QString::number(m_watchers.size()));
+    for (auto& watcher : m_watchers)
+    {
+      if (watcher->isRunning())
+      {
+        watcher->cancel();
+      }
+    }
+  }
+
+  std::unordered_set<std::shared_ptr<QFutureWatcherBase>> m_watchers;
+  std::mutex m_mutex;
+  QObject m_connectionContext;
+};
+
+#endif // TaskCanceler_H

--- a/SampleViewer/TaskCanceler.h
+++ b/SampleViewer/TaskCanceler.h
@@ -18,16 +18,15 @@
 
 // Qt headers
 #include <QFutureWatcher>
-#include <QDebug>
 
 #include <memory>
 #include <mutex>
 #include <unordered_set>
 
 // This class is a helper to ensure any QFuture-based async tasks are
-// canceled upon destruction. This is useful to ensure
-// callbacks aren't being executed at the same time as samples are being
-// shut down
+// canceled upon destruction. This is useful to ensure QFuture
+// continuations aren't being executed at the same time as samples are being
+// destructed
 
 class TaskCanceler
 {
@@ -58,7 +57,6 @@ private:
   void cancelAllTasks_()
   {
     std::lock_guard<std::mutex> lock(m_mutex);
-    qDebug() << QString("canceling %1 tasks").arg(QString::number(m_watchers.size()));
     for (auto& watcher : m_watchers)
     {
       if (watcher->isRunning())


### PR DESCRIPTION
# Description

During sample automation runs, the UN trace and valve isolation trace samples are hitting problems where the sample is destructing at the same time as async operations are completing. We can proactively protect against this by tracking and cleaning up 

This is overkill to deploy to every sample, but it does provide a simple mechanism where needed to cancel running async calls.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
