### PR TITLE
Update samples.pro

### DIFF
--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_CppSamples/ArcGISRuntimeSDKQt_CppSamples.pro
@@ -210,6 +210,8 @@ android {
 }
 
 ios {
+    QMAKE_IOS_DEPLOYMENT_TARGET = 16.0
+
     ios_icon.files = $$files($$PWD/iOS/Images.xcassets/AppIcon.appiconset/iOS_*.png)
     QMAKE_BUNDLE_DATA += ios_icon
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/ArcGISRuntimeSDKQt_QMLSamples/ArcGISRuntimeSDKQt_QMLSamples.pro
@@ -200,6 +200,8 @@ android {
 }
 
 ios {
+    QMAKE_IOS_DEPLOYMENT_TARGET = 16.0
+
     ios_icon.files = $$files($$PWD/iOS/Images.xcassets/AppIcon.appiconset/iOS_*.png)
     QMAKE_BUNDLE_DATA += ios_icon
 

--- a/ArcGISRuntimeSDKQt_SampleViewers/samples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/samples.pro
@@ -4,10 +4,6 @@ mac {
 
 TEMPLATE = subdirs
 
-ios {
-    QMAKE_IOS_DEPLOYMENT_TARGET = 16.0
-}
-
 SUBDIRS += \
     $$PWD/ArcGISRuntimeSDKQt_QMLSamples \
     $$PWD/ArcGISRuntimeSDKQt_CppSamples

--- a/ArcGISRuntimeSDKQt_SampleViewers/samples.pro
+++ b/ArcGISRuntimeSDKQt_SampleViewers/samples.pro
@@ -4,6 +4,10 @@ mac {
 
 TEMPLATE = subdirs
 
+ios {
+    QMAKE_IOS_DEPLOYMENT_TARGET = 16.0
+}
+
 SUBDIRS += \
     $$PWD/ArcGISRuntimeSDKQt_QMLSamples \
     $$PWD/ArcGISRuntimeSDKQt_CppSamples


### PR DESCRIPTION
# Description

Speculative fix. Our CI build machine got updated with a newer version of Xcode and cannot access our minimum iOS SDK version anymore with 100.15.x.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:
