### PR TITLE
Fix linux build, restrict to x64 machines

### DIFF
--- a/SampleViewer/samples.pri
+++ b/SampleViewer/samples.pri
@@ -686,8 +686,8 @@ RESOURCES += \
     "$$SAMPLEPATHCPP/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.qrc" \
     "$$SAMPLEPATHCPP/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.qrc"
 
-# Local Server Only (Linux and Windows)
-!android:!ios:!macx {
+# Local Server Only (Linux x86_64 and Windows x86_64)
+win32:contains(QMAKE_TARGET.arch, x86_64)|unix:contains(QMAKE_TARGET.arch, x86_64) {
   INCLUDEPATH += \
     "$$SAMPLEPATHCPP/LocalServer/LocalServerFeatureLayer" \
     "$$SAMPLEPATHCPP/LocalServer/LocalServerGeoprocessing" \


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement



Verified with build kicked off by vTest. This restricts LocalServer samples to x86_64 linux and x86_64 windows