### PR TITLE
Update snap geometry edits sample

### DIFF
--- a/CppSamples/EditData/SnapGeometryEdits/README.md
+++ b/CppSamples/EditData/SnapGeometryEdits/README.md
@@ -12,7 +12,7 @@ A field worker can create new features by editing and snapping the vertices of a
 
 To create a geometry, press the create button to choose the geometry type you want to create (i.e. points, multipoints, polyline, or polygon) and interactively tap and drag on the map view to create the geometry.
 
-To configure snapping, press the snap settings button to enable or disable snapping and choose which snap sources to snap to.
+Snap settings can be configured by enabling and disabling snapping, feature snapping, geometry guides and snap sources.
 
 To interactively snap a vertex to a feature or graphic, ensure that snapping is enabled for the relevant snap source and move the mouse pointer or drag a vertex to nearby an existing feature or graphic. When the pointer is close to that existing geoelement, the edit position will be adjusted to coincide with (or snap to), edges and vertices of its geometry. Click or release the touch pointer to place the vertex at the snapped location.
 
@@ -31,7 +31,8 @@ To save your edits, press the save button.
 3. Create a `GeometryEditor` and connect it to the map view.
 4. Call `syncSourceSettings` after the map's operational layers are loaded and the geometry editor connected to the map view.
 5. Set `SnapSettings.isEnabled` and `SnapSourceSettings.isEnabled` to true for the `SnapSource` of interest.
-6. Start the geometry editor with a `GeometryType`.
+6. Toggle geometry guides using `SnapSettings.IsGeometryGuidesEnabled` and feature snapping using `SnapSettings.IsFeatureSnappingEnabled`.
+7. Start the geometry editor with a `GeometryType`.
 
 ## Relevant API
 
@@ -56,6 +57,8 @@ Snapping is used to maintain data integrity between different sources of data wh
 To snap to polygon and polyline layers, the recommended approach is to set the `FeatureLayer`'s feature tiling mode to `FeatureTilingMode::EnabledWithFullResolutionWhenSupported` and use the default `ServiceFeatureTable` feature request mode `FeatureRequestMode::OnInteractionCache`. Local data sources, such as geodatabases, always provide full resolution geometries. Point and multipoint feature layers are also always full resolution.
 
 Snapping can be used during interactive edits that move existing vertices using the `VertexTool` or `ReticleVertexTool`. When adding new vertices, snapping also works with a hover event (such as a mouse move without a mouse button press). Using the `ReticleVertexTool` to add and move vertices allows users of touch screen devices to clearly see the visual cues for snapping.
+
+Geometry guides are enabled by default when snapping is enabled. These allow for snapping to a point coinciding with, parallel to, perpendicular to or extending an existing geometry.
 
 ## Tags
 

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
@@ -193,6 +193,18 @@ void SnapGeometryEdits::snappingEnabledStatus(bool snappingCheckedState)
   m_geometryEditor->snapSettings()->setEnabled(snappingCheckedState);
 }
 
+// Toggles geometry guides using the enabled state from the snap settings
+void SnapGeometryEdits::geometryGuidesEnabledStatus(bool geometryGuidesCheckedState)
+{
+  m_geometryEditor->snapSettings()->setGeometryGuidesEnabled(geometryGuidesCheckedState);
+}
+
+// Toggles feature snapping using the enabled state from the snap settings
+void SnapGeometryEdits::featureSnappingEnabledStatus(bool featureSnappingCheckedState)
+{
+  m_geometryEditor->snapSettings()->setFeatureSnappingEnabled(featureSnappingCheckedState);
+}
+
 // Starts the GeometryEditor using the selected geometry type
 void SnapGeometryEdits::startEditor(GeometryEditorMode geometryEditorMode)
 {

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.h
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.h
@@ -73,6 +73,8 @@ public:
   Q_INVOKABLE void deleteSelection();
   Q_INVOKABLE void editorUndo();
   Q_INVOKABLE void snappingEnabledStatus(bool checkedValue);
+  Q_INVOKABLE void geometryGuidesEnabledStatus(bool checkedValue);
+  Q_INVOKABLE void featureSnappingEnabledStatus(bool checkedValue);
   Q_INVOKABLE void displaySnapSources();
   Q_INVOKABLE void enableAllLayersInSection(const QString& section);
 

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.qml
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.qml
@@ -222,9 +222,10 @@ Item {
                     }
                 }
 
-                RowLayout {
+                ColumnLayout {
                     Layout.minimumWidth: optionPanel.width
                     Layout.minimumHeight: 35
+                    spacing: 0
                     Rectangle {
                         Layout.alignment: Qt.AlignLeft
                         Layout.minimumWidth: snapSourceView.width - (snapSourceView.anchors.margins / 2)
@@ -232,7 +233,7 @@ Item {
                         color: "#E9DFEA"
 
                         Text {
-                            text: qsTr("Enabled")
+                            text: qsTr("Snapping enabled")
                             font.pixelSize: 15
                             anchors {
                                 left: parent.left
@@ -248,6 +249,57 @@ Item {
                                 verticalCenter: parent.verticalCenter
                             }
                             onCheckedChanged: snapGeometryEditsSampleModel.snappingEnabledStatus(checked)
+                        }
+                    }
+                    Rectangle {
+                        Layout.alignment: Qt.AlignLeft
+                        Layout.minimumWidth: snapSourceView.width - (snapSourceView.anchors.margins / 2)
+                        Layout.minimumHeight: 35
+                        color: "#E9DFEA"
+
+                        Text {
+                            text: qsTr("Geometry guides")
+                            font.pixelSize: 15
+                            anchors {
+                                left: parent.left
+                                margins: 10
+                                verticalCenter: parent.verticalCenter
+                            }
+                        }
+
+                        Switch {
+                            anchors {
+                                right: parent.right
+                                margins: 10
+                                verticalCenter: parent.verticalCenter
+                            }
+                            onCheckedChanged: snapGeometryEditsSampleModel.geometryGuidesEnabledStatus(checked)
+                        }
+                    }
+                    Rectangle {
+                        Layout.alignment: Qt.AlignLeft
+                        Layout.minimumWidth: snapSourceView.width - (snapSourceView.anchors.margins / 2)
+                        Layout.minimumHeight: 35
+                        color: "#E9DFEA"
+
+
+                        Text {
+                            text: qsTr("Feature snapping")
+                            font.pixelSize: 15
+                            anchors {
+                                left: parent.left
+                                margins: 10
+                                verticalCenter: parent.verticalCenter
+                            }
+                        }
+
+                        Switch {
+                            anchors {
+                                right: parent.right
+                                margins: 10
+                                verticalCenter: parent.verticalCenter
+                            }
+                            onCheckedChanged: snapGeometryEditsSampleModel.featureSnappingEnabledStatus(checked)
                         }
                     }
                 }


### PR DESCRIPTION
# Description

Updated sample to include Feature snapping and Geometry guides with the ability to toggle these settings on and off.

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [ ] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
