### PR TITLE
These paths have changed.

### DIFF
--- a/CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.pro
+++ b/CppSamples/AR/DisplayScenesInTabletopAR/DisplayScenesInTabletopAR.pro
@@ -65,8 +65,8 @@ ios {
 # path of the toolkit relative to the sample
 ARCGIS_TOOLKIT_PATH = $$PWD/../../../arcgis-maps-sdk-toolkit-qt
 
-exists($$ARCGIS_TOOLKIT_PATH/augmentedreality/CppApi/ArCppApi.pri) {
-    include($$ARCGIS_TOOLKIT_PATH/augmentedreality/CppApi/ArCppApi.pri)
+exists($$ARCGIS_TOOLKIT_PATH/augmented_reality/ArApi/ArApi.pri) {
+    include($$ARCGIS_TOOLKIT_PATH/augmented_reality/ArApi/ArApi.pri)
 } else {
     error(ARCGIS_TOOLKIT_PATH is missing which is required to build this application.)
 }

--- a/CppSamples/AR/ExploreScenesInFlyoverAR/ExploreScenesInFlyoverAR.pro
+++ b/CppSamples/AR/ExploreScenesInFlyoverAR/ExploreScenesInFlyoverAR.pro
@@ -72,8 +72,8 @@ android {
 # path of the toolkit relative to the sample
 ARCGIS_TOOLKIT_PATH = $$PWD/../../../arcgis-maps-sdk-toolkit-qt
 
-exists($$ARCGIS_TOOLKIT_PATH/augmentedreality/CppApi/ArCppApi.pri) {
-    include($$ARCGIS_TOOLKIT_PATH/augmentedreality/CppApi/ArCppApi.pri)
+exists($$ARCGIS_TOOLKIT_PATH/augmented_reality/ArApi/ArApi.pri) {
+    include($$ARCGIS_TOOLKIT_PATH/augmented_reality/ArApi/ArApi.pri)
 } else {
     error(ARCGIS_TOOLKIT_PATH is missing which is required to build this application.)
 }


### PR DESCRIPTION
# Description

The AR paths have changed in the toolkit now.

These are the new paths: https://github.com/Esri/arcgis-maps-sdk-toolkit-qt/tree/v.next/augmented_reality/ArApi

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [X] iOS

