### PR TITLE
Change all references of `DisplayGrid` to `ShowGrid`

### DIFF
--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -72,7 +72,7 @@
 #include "../CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.h"
 #include "../CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.h"
 #include "../CppSamples/DisplayInformation/DisplayClusters/DisplayClusters.h"
-#include "../CppSamples/DisplayInformation/DisplayGrid/DisplayGrid.h"
+#include "../CppSamples/DisplayInformation/ShowGrid/ShowGrid.h"
 #include "../CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.h"
 #include "../CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.h"
 #include "../CppSamples/DisplayInformation/GOSymbols/GOSymbols.h"
@@ -419,7 +419,7 @@ void registerCppSampleClasses()
   DisplayDimensions::init();
   DisplayDrawingStatus::init();
   DisplayFeatureLayers::init();
-  DisplayGrid::init();
+  ShowGrid::init();
   DisplayKml::init();
   DisplayKmlNetworkLinks::init();
   DisplayLayerViewDrawState::init();

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -72,7 +72,6 @@
 #include "../CppSamples/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.h"
 #include "../CppSamples/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.h"
 #include "../CppSamples/DisplayInformation/DisplayClusters/DisplayClusters.h"
-#include "../CppSamples/DisplayInformation/ShowGrid/ShowGrid.h"
 #include "../CppSamples/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.h"
 #include "../CppSamples/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.h"
 #include "../CppSamples/DisplayInformation/GOSymbols/GOSymbols.h"
@@ -81,6 +80,7 @@
 #include "../CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.h"
 #include "../CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h"
 #include "../CppSamples/DisplayInformation/ShowCallout/ShowCallout.h"
+#include "../CppSamples/DisplayInformation/ShowGrid/ShowGrid.h"
 #include "../CppSamples/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.h"
 #include "../CppSamples/DisplayInformation/ShowPopup/ShowPopup.h"
 #include "../CppSamples/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.h"
@@ -419,7 +419,6 @@ void registerCppSampleClasses()
   DisplayDimensions::init();
   DisplayDrawingStatus::init();
   DisplayFeatureLayers::init();
-  ShowGrid::init();
   DisplayKml::init();
   DisplayKmlNetworkLinks::init();
   DisplayLayerViewDrawState::init();
@@ -536,6 +535,7 @@ void registerCppSampleClasses()
   SetSurfacePlacementMode::init();
   ShowCallout::init();
   ShowDeviceLocationUsingIndoorPositioning::init();
+  ShowGrid::init();
   ShowLabelsOnLayers::init();
   ShowLocationHistory::init();
   ShowMagnifier::init();

--- a/SampleViewer/samples.pri
+++ b/SampleViewer/samples.pri
@@ -37,7 +37,7 @@ HEADERS += \
     "$$SAMPLEPATHCPP/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.h" \
-    "$$SAMPLEPATHCPP/DisplayInformation/DisplayGrid/DisplayGrid.h" \
+    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/DisplayClusters/DisplayClusters.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.h" \
@@ -264,7 +264,7 @@ SOURCES += \
     "$$SAMPLEPATHCPP/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.cpp" \
-    "$$SAMPLEPATHCPP/DisplayInformation/DisplayGrid/DisplayGrid.cpp" \
+    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/DisplayClusters/DisplayClusters.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp" \
@@ -490,7 +490,7 @@ RESOURCES += \
     "$$SAMPLEPATHCPP/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qrc" \
-    "$$SAMPLEPATHCPP/DisplayInformation/DisplayGrid/DisplayGrid.qrc" \
+    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/DisplayClusters/DisplayClusters.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qrc" \

--- a/SampleViewer/samples.pri
+++ b/SampleViewer/samples.pri
@@ -37,7 +37,6 @@ HEADERS += \
     "$$SAMPLEPATHCPP/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.h" \
-    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/DisplayClusters/DisplayClusters.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.h" \
@@ -48,6 +47,7 @@ HEADERS += \
     "$$SAMPLEPATHCPP/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolImageProvider.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowCallout/ShowCallout.h" \
+    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowPopup/ShowPopup.h" \
     "$$SAMPLEPATHCPP/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.h" \
@@ -264,7 +264,6 @@ SOURCES += \
     "$$SAMPLEPATHCPP/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.cpp" \
-    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/DisplayClusters/DisplayClusters.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.cpp" \
@@ -275,6 +274,7 @@ SOURCES += \
     "$$SAMPLEPATHCPP/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/ReadSymbolsFromMobileStyle/SymbolImageProvider.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowCallout/ShowCallout.cpp" \
+    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowPopup/ShowPopup.cpp" \
     "$$SAMPLEPATHCPP/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.cpp" \
@@ -490,7 +490,6 @@ RESOURCES += \
     "$$SAMPLEPATHCPP/DisplayInformation/ControlAnnotationSublayerVisibility/ControlAnnotationSublayerVisibility.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/CreateSymbolStylesFromWebStyles/CreateSymbolStylesFromWebStyles.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/CustomDictionaryStyle/CustomDictionaryStyle.qrc" \
-    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/DisplayClusters/DisplayClusters.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer_3D/GODictionaryRenderer_3D.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/GODictionaryRenderer/GODictionaryRenderer.qrc" \
@@ -500,6 +499,7 @@ RESOURCES += \
     "$$SAMPLEPATHCPP/DisplayInformation/QueryFeaturesWithArcadeExpression/QueryFeaturesWithArcadeExpression.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/ReadSymbolsFromMobileStyle/ReadSymbolsFromMobileStyle.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowCallout/ShowCallout.qrc" \
+    "$$SAMPLEPATHCPP/DisplayInformation/ShowGrid/ShowGrid.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowLabelsOnLayers/ShowLabelsOnLayers.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/ShowPopup/ShowPopup.qrc" \
     "$$SAMPLEPATHCPP/DisplayInformation/Simple_Marker_Symbol/Simple_Marker_Symbol.qrc" \


### PR DESCRIPTION
# Description

We recently changed the `DisplayGrid` sample to `ShowGrid`, but left in some references to `DisplayGrid`. This is just changing those over to `ShowGrid`

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
