### PR TITLE
Bri12415/5917 android context

### DIFF
--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
@@ -71,7 +71,7 @@ SnapGeometryEdits::SnapGeometryEdits(QObject* parent /* = nullptr */) :
   m_map = new Map(portalItem, this);
 
   #ifdef Q_OS_ANDROID
-    ArcGISRuntimeEnvironment::setAndroidApplicationContext(QJniObject{QNativeInterface::QAndroidApplication::context()});
+  ArcGISRuntimeEnvironment::setAndroidApplicationContext(QJniObject{QNativeInterface::QAndroidApplication::context()});
   #endif
 
   m_geometryEditor = new GeometryEditor(this);

--- a/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
+++ b/CppSamples/EditData/SnapGeometryEdits/SnapGeometryEdits.cpp
@@ -54,6 +54,13 @@
 #include <QFuture>
 #include <QtGlobal>
 
+#ifdef Q_OS_ANDROID
+#include "ArcGISRuntimeEnvironment.h"
+
+#include <QCoreApplication>
+#include <QJniObject>
+#endif
+
 using namespace Esri::ArcGISRuntime;
 
 SnapGeometryEdits::SnapGeometryEdits(QObject* parent /* = nullptr */) :
@@ -62,6 +69,10 @@ SnapGeometryEdits::SnapGeometryEdits(QObject* parent /* = nullptr */) :
 {
   PortalItem* portalItem = new PortalItem("b95fe18073bc4f7788f0375af2bb445e", this);
   m_map = new Map(portalItem, this);
+
+  #ifdef Q_OS_ANDROID
+    ArcGISRuntimeEnvironment::setAndroidApplicationContext(QJniObject{QNativeInterface::QAndroidApplication::context()});
+  #endif
 
   m_geometryEditor = new GeometryEditor(this);
   m_graphicsOverlay = new GraphicsOverlay(this);

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
@@ -38,6 +38,13 @@
 #include <QPermissions>
 #endif
 
+#ifdef Q_OS_ANDROID
+#include "ArcGISRuntimeEnvironment.h"
+
+#include <QCoreApplication>
+#include <QJniObject>
+#endif
+
 using namespace Esri::ArcGISRuntime;
 
 namespace {
@@ -141,6 +148,10 @@ void ShowDeviceLocationUsingIndoorPositioning::checkPermissions()
 // This function uses a helper class `IndoorsLocationDataSourceCreator` to construct the IndoorsLocationDataSource
 void ShowDeviceLocationUsingIndoorPositioning::setupIndoorsLocationDataSource()
 {
+  #ifdef Q_OS_ANDROID
+  ArcGISRuntimeEnvironment::setAndroidApplicationContext(QJniObject{QNativeInterface::QAndroidApplication::context()});
+  #endif
+
   IndoorsLocationDataSourceCreator* indoorsLocationDataSourceCreator = new IndoorsLocationDataSourceCreator(this);
 
   connect(indoorsLocationDataSourceCreator, &IndoorsLocationDataSourceCreator::createIndoorsLocationDataSourceCompleted, this, [this](IndoorsLocationDataSource* indoorsLDS)


### PR DESCRIPTION
# Description

Add usage of `ArcGISRuntimeEnvironment::setAndroidApplicationContext` where applicable in samples. In both cases, this function needs to be called before the object using the android context is constructed.

For `SnapGeometryEdits` that is before `m_geometryEditor` is created.

For `ShowDeviceLocationIndoors` that is before the `IndoorsLocationDataSourceCreator` is created, which then creates the `IndoorsLocationDataSource` (this can be moved closer to actual creation of `ILDS` if preferred).

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
