### PR TITLE
Split apart connection logic from permission requests logic

### DIFF
--- a/CppSamples/Search/FindPlace/FindPlace.h
+++ b/CppSamples/Search/FindPlace/FindPlace.h
@@ -79,7 +79,7 @@ private:
   void setPoiTextHasFocus(bool hasFocus);
   Esri::ArcGISRuntime::GeocodeParameters createParameters();
   void onGeocodingCompleted_(const QList<Esri::ArcGISRuntime::GeocodeResult>& results);
-  void startLocationPermission();
+  void initiateLocation();
 
 private:
   Esri::ArcGISRuntime::Map* m_map = nullptr;


### PR DESCRIPTION
# Description

Splits apart the functionality of starting the location display from connecting signals. We're close to release, so I verified this one pretty thoroughly.

Verified w/ MacOS, iOS, and Android. Both stand alone and sample viewer. All release builds.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [x] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [x] All variable and method names are camel case
- [x] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
