### PR TITLE
Add qt bluetooth module to sample viewer and stand alone sample

### DIFF
--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.pro
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.pro
@@ -23,7 +23,7 @@ CONFIG += c++17
 
 # additional modules are pulled in via arcgisruntime.pri
 QT += opengl qml quick
-android|ios: QT += bluetooth
+android|ios|macos: QT += bluetooth
 
 TEMPLATE = app
 TARGET = ShowDeviceLocationUsingIndoorPositioning

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -20,7 +20,7 @@
 TEMPLATE = app
 QT += core gui xml network qml quick positioning sensors multimedia
 QT += widgets quickcontrols2 opengl webview core5compat websockets texttospeech
-android|ios: QT += bluetooth
+android|ios|macos: QT += bluetooth
 TARGET = ArcGISQt_Samples
 DEFINES += Qt_Version=\"$$QT_VERSION\"
 SAMPLEPATHCPP = $$PWD/../CppSamples


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS


I believe macos also requires the `bluetooth` qt module for the `ShowDeviceLocationUsingIndoorPositioning` sample. So adding it to the standalone and the sample viewer.