### PR TITLE
Workaround for iOS.

### DIFF
--- a/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
+++ b/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
@@ -56,6 +56,25 @@ ios {
         $$PWD/Info.plist
 
     QMAKE_INFO_PLIST = $$PWD/Info.plist
+
+    # workaround for https://bugreports.qt.io/browse/QTBUG-129651
+    # ArcGIS Maps SDK for Qt adds 'QMAKE_RPATHDIR = @executable_path/Frameworks'
+    # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
+    # so in order for them to be found, we need to add @executable_path to the
+    # search path.
+    QMAKE_LFLAGS += -F$$(QTDIR)/lib/ffmpeg -Wl,-rpath,@executable_path
+    LIBS += -framework libavcodec \
+            -framework libavformat \
+            -framework libavutil \
+            -framework libswresample \
+            -framework libswscale
+    ffmpeg.files = $$(QTDIR)/lib/ffmpeg/libavcodec.framework \
+                   $$(QTDIR)/lib/ffmpeg/libavformat.framework \
+                   $$(QTDIR)/lib/ffmpeg/libavutil.framework \
+                   $$(QTDIR)/lib/ffmpeg/libswresample.framework \
+                   $$(QTDIR)/lib/ffmpeg/libswscale.framework
+    ffmpeg.path = Frameworks
+    QMAKE_BUNDLE_DATA += ffmpeg
 }
 
 android {

--- a/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
+++ b/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
@@ -62,7 +62,9 @@ ios {
     # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
     # so in order for them to be found, we need to add @executable_path to the
     # search path.
-    QMAKE_LFLAGS += -F$$(QTDIR)/lib/ffmpeg -Wl,-rpath,@executable_path
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
+    QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
     LIBS += -framework libavcodec \
             -framework libavformat \
             -framework libavutil \

--- a/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
+++ b/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
@@ -70,11 +70,11 @@ ios {
             -framework libavutil \
             -framework libswresample \
             -framework libswscale
-    ffmpeg.files = $$(QTDIR)/lib/ffmpeg/libavcodec.framework \
-                   $$(QTDIR)/lib/ffmpeg/libavformat.framework \
-                   $$(QTDIR)/lib/ffmpeg/libavutil.framework \
-                   $$(QTDIR)/lib/ffmpeg/libswresample.framework \
-                   $$(QTDIR)/lib/ffmpeg/libswscale.framework
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.framework \
+                   $${FFMPEG_LIB_DIR}/libavformat.framework \
+                   $${FFMPEG_LIB_DIR}/libavutil.framework \
+                   $${FFMPEG_LIB_DIR}/libswresample.framework \
+                   $${FFMPEG_LIB_DIR}/libswscale.framework
     ffmpeg.path = Frameworks
     QMAKE_BUNDLE_DATA += ffmpeg
 }

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -251,7 +251,9 @@ ios {
     # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
     # so in order for them to be found, we need to add @executable_path to the
     # search path.
-    QMAKE_LFLAGS += -F$$(QTDIR)/lib/ffmpeg -Wl,-rpath,@executable_path
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
+    QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
     LIBS += -framework libavcodec \
             -framework libavformat \
             -framework libavutil \

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -37,7 +37,7 @@ exists($$PWD/../../../DevBuildCpp.pri) {
   # use the Esri dev build script
   include ($$PWD/../../../DevBuildCpp.pri)
   # include the toolkitcpp.pri, which contains all the toolkit resources
-  include($$PWD/../../toolkit/uitools/toolkitcpp.pri)
+  include($$PWD/../../toolkit/uitools/toolkitcpp/toolkitcpp.pri)
 
   INCLUDEPATH += \
       $$SAMPLEPATHCPP \
@@ -52,8 +52,8 @@ exists($$PWD/../../../DevBuildCpp.pri) {
   CONFIG += c++17
 
   # include the toolkitcpp.pri, which contains all the toolkit resources
-  !include($$PWD/../arcgis-maps-sdk-toolkit-qt/uitools/toolkitcpp.pri) {
-    message("ERROR: Cannot find toolkitcpp.pri at path:" $$PWD/../arcgis-maps-sdk-toolkit-qt/uitools/toolkitcpp.pri)
+  !include($$PWD/../arcgis-maps-sdk-toolkit-qt/uitools/toolkitcpp/toolkitcpp.pri) {
+    message("ERROR: Cannot find toolkitcpp.pri at path:" $$PWD/../arcgis-maps-sdk-toolkit-qt/uitools/toolkitcpp/toolkitcpp.pri)
     message("Please ensure the Qt Toolkit repository is cloned and the path above is correct.")
   }
 
@@ -246,6 +246,25 @@ android {
 }
 
 ios {
+    # workaround for https://bugreports.qt.io/browse/QTBUG-129651
+    # ArcGIS Maps SDK for Qt adds 'QMAKE_RPATHDIR = @executable_path/Frameworks'
+    # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
+    # so in order for them to be found, we need to add @executable_path to the
+    # search path.
+    QMAKE_LFLAGS += -F$$(QTDIR)/lib/ffmpeg -Wl,-rpath,@executable_path
+    LIBS += -framework libavcodec \
+            -framework libavformat \
+            -framework libavutil \
+            -framework libswresample \
+            -framework libswscale
+    ffmpeg.files = $$(QTDIR)/lib/ffmpeg/libavcodec.framework \
+                   $$(QTDIR)/lib/ffmpeg/libavformat.framework \
+                   $$(QTDIR)/lib/ffmpeg/libavutil.framework \
+                   $$(QTDIR)/lib/ffmpeg/libswresample.framework \
+                   $$(QTDIR)/lib/ffmpeg/libswscale.framework
+    ffmpeg.path = Frameworks
+    QMAKE_BUNDLE_DATA += ffmpeg
+
     ios_icon.files = $$files($$PWD/iOS/Images.xcassets/AppIcon.appiconset/iOS_*.png)
     QMAKE_BUNDLE_DATA += ios_icon
 

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -259,11 +259,11 @@ ios {
             -framework libavutil \
             -framework libswresample \
             -framework libswscale
-    ffmpeg.files = $$(QTDIR)/lib/ffmpeg/libavcodec.framework \
-                   $$(QTDIR)/lib/ffmpeg/libavformat.framework \
-                   $$(QTDIR)/lib/ffmpeg/libavutil.framework \
-                   $$(QTDIR)/lib/ffmpeg/libswresample.framework \
-                   $$(QTDIR)/lib/ffmpeg/libswscale.framework
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.framework \
+                   $${FFMPEG_LIB_DIR}/libavformat.framework \
+                   $${FFMPEG_LIB_DIR}/libavutil.framework \
+                   $${FFMPEG_LIB_DIR}/libswresample.framework \
+                   $${FFMPEG_LIB_DIR}/libswscale.framework
     ffmpeg.path = Frameworks
     QMAKE_BUNDLE_DATA += ffmpeg
 

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -120,6 +120,27 @@ exists($$PWD/../../../DevBuildCpp.pri) {
 
   ios {
     PLATFORM = "iOS"
+
+    # workaround for https://bugreports.qt.io/browse/QTBUG-129651
+    # ArcGIS Maps SDK for Qt adds 'QMAKE_RPATHDIR = @executable_path/Frameworks'
+    # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
+    # so in order for them to be found, we need to add @executable_path to the
+    # search path.
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
+    FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
+    QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
+    LIBS += -framework libavcodec \
+            -framework libavformat \
+            -framework libavutil \
+            -framework libswresample \
+            -framework libswscale
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.framework \
+                   $${FFMPEG_LIB_DIR}/libavformat.framework \
+                   $${FFMPEG_LIB_DIR}/libavutil.framework \
+                   $${FFMPEG_LIB_DIR}/libswresample.framework \
+                   $${FFMPEG_LIB_DIR}/libswscale.framework
+    ffmpeg.path = Frameworks
+    QMAKE_BUNDLE_DATA += ffmpeg
   }
 
   DEFINES += BUILD_FROM_SETUP
@@ -246,27 +267,6 @@ android {
 }
 
 ios {
-    # workaround for https://bugreports.qt.io/browse/QTBUG-129651
-    # ArcGIS Maps SDK for Qt adds 'QMAKE_RPATHDIR = @executable_path/Frameworks'
-    # and ffmpeg frameworks have embedded '@rpath/Frameworks' path.
-    # so in order for them to be found, we need to add @executable_path to the
-    # search path.
-    FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
-    FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
-    QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
-    LIBS += -framework libavcodec \
-            -framework libavformat \
-            -framework libavutil \
-            -framework libswresample \
-            -framework libswscale
-    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.framework \
-                   $${FFMPEG_LIB_DIR}/libavformat.framework \
-                   $${FFMPEG_LIB_DIR}/libavutil.framework \
-                   $${FFMPEG_LIB_DIR}/libswresample.framework \
-                   $${FFMPEG_LIB_DIR}/libswscale.framework
-    ffmpeg.path = Frameworks
-    QMAKE_BUNDLE_DATA += ffmpeg
-
     ios_icon.files = $$files($$PWD/iOS/Images.xcassets/AppIcon.appiconset/iOS_*.png)
     QMAKE_BUNDLE_DATA += ios_icon
 


### PR DESCRIPTION
# Description

We need to manually link and deliver ffmpeg libraries bundled with Qt whenever multimedia capabilities are required on iOS. This is needed until https://bugreports.qt.io/browse/QTBUG-129651 is solved.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [x] iOS
