### PR TITLE
Add ESRI_AUTOMATION_TEST_SUSE_FONT_PATH

### DIFF
--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -216,10 +216,6 @@ RESOURCES += \
 
 DEFINES += QT_DEPRECATED_WARNINGS
 
-# There is a known issue on certain Linux distros with newer versions of Qt
-# where no fonts are loaded by default. Work around it by loading a specific font
-DEFINES += ESRI_AUTOMATION_TEST_SUSE_FONT_PATH=$$(ESRI_AUTOMATION_TEST_SUSE_FONT_PATH)
-
 #-------------------------------------------------
 # Application Icon
 #-------------------------------------------------

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -215,6 +215,11 @@ RESOURCES += \
     $$PWD/imports.qrc
 
 DEFINES += QT_DEPRECATED_WARNINGS
+
+# There is a known issue on certain Linux distros with newer versions of Qt
+# where no fonts are loaded by default. Work around it by loading a specific font
+DEFINES += ESRI_AUTOMATION_TEST_SUSE_FONT_PATH=$$(ESRI_AUTOMATION_TEST_SUSE_FONT_PATH)
+
 #-------------------------------------------------
 # Application Icon
 #-------------------------------------------------

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -305,11 +305,13 @@ int main(int argc, char *argv[])
   QGuiApplication::setOrganizationName("Esri");
   QApplication app(argc, argv);
   
-  #ifdef ESRI_AUTOMATION_TEST_SUSE_FONT_PATH
-  // There is a known issue on certain Linux distros with newer versions of Qt 
-  // where no fonts are loaded by default. Work around it by loading a specific font
-  QFontDatabase::addApplicationFont(QUOTE(ESRI_AUTOMATION_TEST_SUSE_FONT_PATH));
-  #endif // ESRI_AUTOMATION_TEST_SUSE_FONT
+  const auto fontPath = qEnvironmentVariable("ESRI_AUTOMATION_TEST_SUSE_FONT_PATH");
+  if (!fontPath.isEmpty())
+  {
+    // There is a known issue on certain Linux distros with newer versions of Qt
+    // where no fonts are loaded by default. Work around it by loading a specific font
+    QFontDatabase::addApplicationFont(fontPath);
+  }
   
   // register sample viewer classes
   registerClasses();

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
   #ifdef ESRI_AUTOMATION_TEST_SUSE_FONT_PATH
   // There is a known issue on certain Linux distros with newer versions of Qt 
   // where no fonts are loaded by default. Work around it by loading a specific font
-  QFontDatabase::addApplicationFont(STRINGIZE(ESRI_AUTOMATION_TEST_SUSE_FONT_PATH));
+  QFontDatabase::addApplicationFont(QUOTE(ESRI_AUTOMATION_TEST_SUSE_FONT_PATH));
   #endif // ESRI_AUTOMATION_TEST_SUSE_FONT
   
   // register sample viewer classes

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -302,10 +302,15 @@ int main(int argc, char *argv[])
 #endif // QT_WEBVIEW_WEBENGINE_BACKEND
 
   QGuiApplication::setApplicationName("ArcGIS Maps Qt Samples");
-
   QGuiApplication::setOrganizationName("Esri");
   QApplication app(argc, argv);
-
+  
+  #ifdef ESRI_AUTOMATION_TEST_SUSE_FONT_PATH
+  // There is a known issue on certain Linux distros with newer versions of Qt 
+  // where no fonts are loaded by default. Work around it by loading a specific font
+  QFontDatabase::addApplicationFont(STRINGIZE(ESRI_AUTOMATION_TEST_SUSE_FONT_PATH));
+  #endif // ESRI_AUTOMATION_TEST_SUSE_FONT
+  
   // register sample viewer classes
   registerClasses();
 

--- a/SampleViewer/mainSample.cpp
+++ b/SampleViewer/mainSample.cpp
@@ -304,14 +304,16 @@ int main(int argc, char *argv[])
   QGuiApplication::setApplicationName("ArcGIS Maps Qt Samples");
   QGuiApplication::setOrganizationName("Esri");
   QApplication app(argc, argv);
-  
-  const auto fontPath = qEnvironmentVariable("ESRI_AUTOMATION_TEST_SUSE_FONT_PATH");
-  if (!fontPath.isEmpty())
+
+#ifdef Q_OS_LINUX
+  if (qEnvironmentVariableIsSet("ESRI_AUTOMATION_TEST_SUSE_FONT_PATH"))
   {
+    const auto fontPath = qEnvironmentVariable("ESRI_AUTOMATION_TEST_SUSE_FONT_PATH");
     // There is a known issue on certain Linux distros with newer versions of Qt
     // where no fonts are loaded by default. Work around it by loading a specific font
     QFontDatabase::addApplicationFont(fontPath);
   }
+#endif
   
   // register sample viewer classes
   registerClasses();


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

Fix text rendering issue on SUSE 15 with Qt > 7

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [x] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
