### PR TITLE
Remove qt version workarounds from location samples

### DIFF
--- a/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
+++ b/CppSamples/Maps/DisplayDeviceLocation/DisplayDeviceLocation.cpp
@@ -29,10 +29,7 @@
 #include "MapTypes.h"
 #include "MapViewTypes.h"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)) || defined(Q_OS_IOS) || defined(Q_OS_MACOS) || defined(Q_OS_ANDROID)
-#define PERMISSIONS_PLATFORM
 #include <QPermissions>
-#endif
 
 using namespace Esri::ArcGISRuntime;
 
@@ -78,8 +75,6 @@ void DisplayDeviceLocation::componentComplete()
 
 void DisplayDeviceLocation::startLocationDisplay()
 {
-  // https://bugreports.qt.io/browse/QTBUG-116178
-#ifdef PERMISSIONS_PLATFORM
   QLocationPermission locationPermission{};
   locationPermission.setAccuracy(QLocationPermission::Accuracy::Precise);
   locationPermission.setAvailability(QLocationPermission::Availability::WhenInUse);
@@ -98,9 +93,6 @@ void DisplayDeviceLocation::startLocationDisplay()
     emit locationPermissionDenied();
     return;
   }
-#else
-  m_mapView->locationDisplay()->start();
-#endif
 }
 
 void DisplayDeviceLocation::stopLocationDisplay()

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ShowDeviceLocationUsingIndoorPositioning.cpp
@@ -33,10 +33,7 @@
 #include "MapViewTypes.h"
 #include "PortalItem.h"
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)) || defined(Q_OS_IOS) || defined(Q_OS_MACOS) || defined(Q_OS_ANDROID)
-#define PERMISSIONS_PLATFORM
 #include <QPermissions>
-#endif
 
 #ifdef Q_OS_ANDROID
 #include "ArcGISRuntimeEnvironment.h"
@@ -91,30 +88,22 @@ void ShowDeviceLocationUsingIndoorPositioning::setMapView(MapQuickView* mapView)
   m_mapView = mapView;
   m_mapView->setMap(m_map);
 
-  // Issue expected with Android - https://bugreports.qt.io/browse/QTBUG-130301
-  #ifdef PERMISSIONS_PLATFORM
-    requestBluetoothThenLocationPermissions();
-  #else
-    setupIndoorsLocationDataSource();
-  #endif
+  requestBluetoothThenLocationPermissions();
 
   emit mapViewChanged();
 }
 
 void ShowDeviceLocationUsingIndoorPositioning::requestBluetoothThenLocationPermissions()
 {
-  #ifdef PERMISSIONS_PLATFORM
-    qApp->requestPermission(QBluetoothPermission{}, [this](const QPermission& permission)
+  qApp->requestPermission(QBluetoothPermission{}, [this](const QPermission& permission)
   {
     Q_UNUSED(permission);
     requestLocationPermissionThenSetupILDS();
   });
-  #endif // PERMISSIONS_PLATFORM
 }
 
 void ShowDeviceLocationUsingIndoorPositioning::requestLocationPermissionThenSetupILDS()
 {
-  #ifdef PERMISSIONS_PLATFORM
   QLocationPermission locationPermission{};
   locationPermission.setAccuracy(QLocationPermission::Accuracy::Precise);
   locationPermission.setAvailability(QLocationPermission::Availability::WhenInUse);
@@ -124,12 +113,10 @@ void ShowDeviceLocationUsingIndoorPositioning::requestLocationPermissionThenSetu
     checkPermissions();
     setupIndoorsLocationDataSource();
   });
-  #endif // PERMISSIONS_PLATFORM
 }
 
 void ShowDeviceLocationUsingIndoorPositioning::checkPermissions()
 {
-  #ifdef PERMISSIONS_PLATFORM
   if (qApp->checkPermission(QBluetoothPermission{}) == Qt::PermissionStatus::Denied)
   {
     emit bluetoothPermissionDenied();
@@ -142,7 +129,6 @@ void ShowDeviceLocationUsingIndoorPositioning::checkPermissions()
   {
     emit locationPermissionDenied();
   }
-  #endif // PERMISSIONS_PLATFORM
 }
 
 // This function uses a helper class `IndoorsLocationDataSourceCreator` to construct the IndoorsLocationDataSource

--- a/CppSamples/Search/FindPlace/FindPlace.cpp
+++ b/CppSamples/Search/FindPlace/FindPlace.cpp
@@ -52,10 +52,7 @@
 #include <QUrl>
 #include <QUuid>
 
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)) || defined(Q_OS_IOS) || defined(Q_OS_MACOS) || defined(Q_OS_ANDROID)
-#define PERMISSIONS_PLATFORM
 #include <QPermissions>
-#endif
 
 using namespace Esri::ArcGISRuntime;
 
@@ -141,7 +138,6 @@ void FindPlace::connectSignals()
 
 void FindPlace::initiateLocation()
 {
-#ifdef PERMISSIONS_PLATFORM
   QLocationPermission locationPermission{};
   locationPermission.setAccuracy(QLocationPermission::Accuracy::Precise);
   locationPermission.setAvailability(QLocationPermission::Availability::WhenInUse);
@@ -159,10 +155,6 @@ void FindPlace::initiateLocation()
       m_mapView->locationDisplay()->start();
       return;
   }
-#else
-  m_mapView->locationDisplay()->setAutoPanMode(LocationDisplayAutoPanMode::Recenter);
-  m_mapView->locationDisplay()->start();
-#endif
 }
 
 void FindPlace::addGraphicsOverlay()


### PR DESCRIPTION
# Description

These workarounds were put in place for the oddities on location permissions between 6.5.6 and 6.6.x. But now that we've upgraded our qt version, the check for `#if (QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)) || ...` will always return true, regardless of the platform we are on. So `PLATFORM_PERMISSIONS` is always defined now.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [x] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [x] macOS
- [x] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
