### PR TITLE
Remove extract_android_style entry from manifest file

### DIFF
--- a/SampleViewer/android/AndroidManifest.xml
+++ b/SampleViewer/android/AndroidManifest.xml
@@ -25,7 +25,6 @@
             </intent-filter>
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
             <meta-data android:name="android.app.arguments" android:value="-- %%INSERT_APP_ARGUMENTS%% --"/>
-            <meta-data android:name="android.app.extract_android_style" android:value="default"/>
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
# Description

In our provided `AndroidManifest.xml` file for the `SampleViewer`, we have this entry:
```
<meta-data android:name="android.app.extract_android_style" android:value="default"/>
```

But according to the [Qt documentation](https://doc.qt.io/qt-6/android-manifest-file-configuration.html#style-extraction), `default` is intended to be used with either quick controls 1 or widgets. We use [quickcontrols2](https://github.com/Esri/arcgis-maps-sdk-samples-qt/blob/v.next/SampleViewer/SampleViewer.pro#L22) in our sample viewer.

The [default value](https://doc.qt.io/qt-6/android-manifest-file-configuration.html#qt-specific-meta-data) for the `extract_android_style` is `minimal`, which corresponds to quick controls 2. So lets just remove the entry and use the default value.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [x] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS
