### PR TITLE
Aji13187/xcframework ffmpeg for qt6.8.3

### DIFF
--- a/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
+++ b/CppSamples/Layers/PlayAKmlTour/PlayAKmlTour.pro
@@ -65,16 +65,21 @@ ios {
     FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
     FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
     QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
+    versionAtLeast(QT_VERSION, 6.8.3) {
+      FRAMEWORK = "xcframework"
+    } else {
+      FRAMEWORK = "framework"
+    }
     LIBS += -framework libavcodec \
             -framework libavformat \
             -framework libavutil \
             -framework libswresample \
             -framework libswscale
-    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.framework \
-                   $${FFMPEG_LIB_DIR}/libavformat.framework \
-                   $${FFMPEG_LIB_DIR}/libavutil.framework \
-                   $${FFMPEG_LIB_DIR}/libswresample.framework \
-                   $${FFMPEG_LIB_DIR}/libswscale.framework
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavformat.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavutil.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswresample.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswscale.$${FRAMEWORK}
     ffmpeg.path = Frameworks
     QMAKE_BUNDLE_DATA += ffmpeg
 }

--- a/SampleViewer/SampleViewer.pro
+++ b/SampleViewer/SampleViewer.pro
@@ -129,16 +129,21 @@ exists($$PWD/../../../DevBuildCpp.pri) {
     FFMPEG_LIB_DIR = $$absolute_path($$replace(QMAKE_QMAKE, "qmake6", "../../ios/lib/ffmpeg"))
     FFMPEG_LIB_DIR = $$absolute_path($$replace(FFMPEG_LIB_DIR, "qmake", "../../ios/lib/ffmpeg"))
     QMAKE_LFLAGS += -F$${FFMPEG_LIB_DIR} -Wl,-rpath,@executable_path
+    versionAtLeast(QT_VERSION, 6.8.3) {
+      FRAMEWORK = "xcframework"
+    } else {
+      FRAMEWORK = "framework"
+    }
     LIBS += -framework libavcodec \
             -framework libavformat \
             -framework libavutil \
             -framework libswresample \
             -framework libswscale
-    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.framework \
-                   $${FFMPEG_LIB_DIR}/libavformat.framework \
-                   $${FFMPEG_LIB_DIR}/libavutil.framework \
-                   $${FFMPEG_LIB_DIR}/libswresample.framework \
-                   $${FFMPEG_LIB_DIR}/libswscale.framework
+    ffmpeg.files = $${FFMPEG_LIB_DIR}/libavcodec.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavformat.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libavutil.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswresample.$${FRAMEWORK} \
+                   $${FFMPEG_LIB_DIR}/libswscale.$${FRAMEWORK}
     ffmpeg.path = Frameworks
     QMAKE_BUNDLE_DATA += ffmpeg
   }


### PR DESCRIPTION
# Description

Updated pro files for Qt6.83 xcframework ffmpeg libraries.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [x] iOS

## Checklist

- [x] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
