### PR TITLE
James/reset auth state

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -1,5 +1,20 @@
-// [Legal]
-// Copyright 2022 Esri.
+// COPYRIGHT 2025 ESRI
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file SampleManager.cpp
+
+#include "pch.hpp"
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +27,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // [Legal]
-
-#include "pch.hpp"
 
 #include <QByteArray>
 #include <QDebug>
@@ -406,9 +419,10 @@ void SampleManager::setDownloadProgress(double progress)
   emit downloadProgressChanged();
 }
 
-void SampleManager::clearCredentialCache()
+void SampleManager::resetAuthenticationState()
 {
   AuthenticationManager::credentialCache()->removeAndRevokeAllCredentials();
+  AuthenticationManager::setCredentialCacheEnabled(true);
 }
 
 bool SampleManager::dataItemsExists()

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -1,20 +1,5 @@
-// COPYRIGHT 2025 ESRI
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file SampleManager.cpp
-
-#include "pch.hpp"
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // [Legal]
+
+#include "pch.hpp"
 
 #include <QByteArray>
 #include <QDebug>

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -1,18 +1,5 @@
-// COPYRIGHT 2025 ESRI
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file SampleManager.h
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -1,5 +1,18 @@
-// [Legal]
-// Copyright 2022 Esri.
+// COPYRIGHT 2025 ESRI
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file SampleManager.h
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,7 +83,7 @@ public:
   Q_INVOKABLE void init();
 
   Q_INVOKABLE bool dataItemsExists();
-  Q_INVOKABLE void clearCredentialCache();
+  Q_INVOKABLE void resetAuthenticationState();
   Q_INVOKABLE void downloadAllDataItems();
   Q_INVOKABLE void downloadDataItemsCurrentSample();
   Q_INVOKABLE bool deleteAllOfflineData();
@@ -158,7 +171,6 @@ private:
   void setDownloadFailed(bool didFail);
   SampleManager::Reachability reachability() const;
   QString api() const;
-
 
 private:
   QQueue<DataItem*> m_dataItems;

--- a/SampleViewer/qml/main.qml
+++ b/SampleViewer/qml/main.qml
@@ -228,7 +228,7 @@ ApplicationWindow {
 
         function onCurrentSampleChanged() {
             clearSample();
-            SampleManager.clearCredentialCache();
+            SampleManager.resetAuthenticationState();
 
             const noAuthSamplesList = [
                                         "qrc:/Samples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.qml",


### PR DESCRIPTION
Some samples disable credential caching for unknown reasons. The history on those changes goes back way into the 100.x release, so I don't want to change that. This seems like the safer and better fix, but there is a risk of side effects.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
