### PR TITLE
Update the bundle id for Xcode 16 compatibility.

### DIFF
--- a/CppSamples/Analysis/AnalyzeHotspots/Info.plist
+++ b/CppSamples/Analysis/AnalyzeHotspots/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/AnalyzeViewshed/Info.plist
+++ b/CppSamples/Analysis/AnalyzeViewshed/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/DistanceMeasurementAnalysis/Info.plist
+++ b/CppSamples/Analysis/DistanceMeasurementAnalysis/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/LineOfSightGeoElement/Info.plist
+++ b/CppSamples/Analysis/LineOfSightGeoElement/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/LineOfSightLocation/Info.plist
+++ b/CppSamples/Analysis/LineOfSightLocation/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/StatisticalQuery/Info.plist
+++ b/CppSamples/Analysis/StatisticalQuery/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/StatisticalQueryGroupSort/Info.plist
+++ b/CppSamples/Analysis/StatisticalQueryGroupSort/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/ViewshedCamera/Info.plist
+++ b/CppSamples/Analysis/ViewshedCamera/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/ViewshedGeoElement/Info.plist
+++ b/CppSamples/Analysis/ViewshedGeoElement/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Analysis/ViewshedLocation/Info.plist
+++ b/CppSamples/Analysis/ViewshedLocation/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/CloudAndPortal/AddItemsToPortal/Info.plist
+++ b/CppSamples/CloudAndPortal/AddItemsToPortal/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/Info.plist
+++ b/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/CloudAndPortal/PortalUserInfo/Info.plist
+++ b/CppSamples/CloudAndPortal/PortalUserInfo/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/CloudAndPortal/SearchForWebmap/Info.plist
+++ b/CppSamples/CloudAndPortal/SearchForWebmap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/CloudAndPortal/ShowOrgBasemaps/Info.plist
+++ b/CppSamples/CloudAndPortal/ShowOrgBasemaps/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/CloudAndPortal/TokenAuthentication/Info.plist
+++ b/CppSamples/CloudAndPortal/TokenAuthentication/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/AddGraphicsWithRenderer/Info.plist
+++ b/CppSamples/DisplayInformation/AddGraphicsWithRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/BuildLegend/Info.plist
+++ b/CppSamples/DisplayInformation/BuildLegend/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/Info.plist
+++ b/CppSamples/DisplayInformation/ControlAnnotationSublayerVisibility/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/CustomDictionaryStyle/Info.plist
+++ b/CppSamples/DisplayInformation/CustomDictionaryStyle/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/DisplayClusters/Info.plist
+++ b/CppSamples/DisplayInformation/DisplayClusters/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/GODictionaryRenderer/Info.plist
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/GODictionaryRenderer_3D/Info.plist
+++ b/CppSamples/DisplayInformation/GODictionaryRenderer_3D/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/GOSymbols/Info.plist
+++ b/CppSamples/DisplayInformation/GOSymbols/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/IdentifyGraphics/Info.plist
+++ b/CppSamples/DisplayInformation/IdentifyGraphics/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/Picture_Marker_Symbol/Info.plist
+++ b/CppSamples/DisplayInformation/Picture_Marker_Symbol/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/Info.plist
+++ b/CppSamples/DisplayInformation/QueryFeaturesWithArcadeExpression/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/Info.plist
+++ b/CppSamples/DisplayInformation/ReadSymbolsFromMobileStyle/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/ShowCallout/Info.plist
+++ b/CppSamples/DisplayInformation/ShowCallout/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/ShowGrid/Info.plist
+++ b/CppSamples/DisplayInformation/ShowGrid/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/ShowLabelsOnLayers/Info.plist
+++ b/CppSamples/DisplayInformation/ShowLabelsOnLayers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/ShowPopup/Info.plist
+++ b/CppSamples/DisplayInformation/ShowPopup/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/Simple_Marker_Symbol/Info.plist
+++ b/CppSamples/DisplayInformation/Simple_Marker_Symbol/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/Simple_Renderer/Info.plist
+++ b/CppSamples/DisplayInformation/Simple_Renderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/SymbolizeShapefile/Info.plist
+++ b/CppSamples/DisplayInformation/SymbolizeShapefile/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/DisplayInformation/Unique_Value_Renderer/Info.plist
+++ b/CppSamples/DisplayInformation/Unique_Value_Renderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/AddFeaturesFeatureService/Info.plist
+++ b/CppSamples/EditData/AddFeaturesFeatureService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/DeleteFeaturesFeatureService/Info.plist
+++ b/CppSamples/EditData/DeleteFeaturesFeatureService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/EditAndSyncFeatures/Info.plist
+++ b/CppSamples/EditData/EditAndSyncFeatures/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/EditFeatureAttachments/Info.plist
+++ b/CppSamples/EditData/EditFeatureAttachments/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleIcons~ipad</key>
     <dict/>
     <key>CFBundleIdentifier</key>
-    <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+    <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>

--- a/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/Info.plist
+++ b/CppSamples/EditData/EditFeaturesWithFeatureLinkedAnnotation/Info.plist
@@ -11,7 +11,7 @@
         <key>CFBundleIcons~ipad</key>
         <dict/>
         <key>CFBundleIdentifier</key>
-        <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+        <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
         <key>CFBundleName</key>
         <string>${PRODUCT_NAME}</string>
         <key>CFBundlePackageType</key>

--- a/CppSamples/EditData/EditKmlGroundOverlay/Info.plist
+++ b/CppSamples/EditData/EditKmlGroundOverlay/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/EditWithBranchVersioning/Info.plist
+++ b/CppSamples/EditData/EditWithBranchVersioning/Info.plist
@@ -11,7 +11,7 @@
         <key>CFBundleIcons~ipad</key>
         <dict/>
         <key>CFBundleIdentifier</key>
-        <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+        <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
         <key>CFBundleName</key>
         <string>${PRODUCT_NAME}</string>
         <key>CFBundlePackageType</key>

--- a/CppSamples/EditData/SnapGeometryEdits/Info.plist
+++ b/CppSamples/EditData/SnapGeometryEdits/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/UpdateAttributesFeatureService/Info.plist
+++ b/CppSamples/EditData/UpdateAttributesFeatureService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/EditData/UpdateGeometryFeatureService/Info.plist
+++ b/CppSamples/EditData/UpdateGeometryFeatureService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/ControlTimeExtentTimeSlider/Info.plist
+++ b/CppSamples/Features/ControlTimeExtentTimeSlider/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/CreateMobileGeodatabase/Info.plist
+++ b/CppSamples/Features/CreateMobileGeodatabase/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/FeatureLayerChangeRenderer/Info.plist
+++ b/CppSamples/Features/FeatureLayerChangeRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/FeatureLayerDictionaryRenderer/Info.plist
+++ b/CppSamples/Features/FeatureLayerDictionaryRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/FeatureLayerQuery/Info.plist
+++ b/CppSamples/Features/FeatureLayerQuery/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/FeatureLayerSelection/Info.plist
+++ b/CppSamples/Features/FeatureLayerSelection/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/Info.plist
+++ b/CppSamples/Features/FilterByDefinitionExpressionOrDisplayFilter/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/Info.plist
+++ b/CppSamples/Features/GenerateGeodatabaseReplicaFromFeatureService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/ListRelatedFeatures/Info.plist
+++ b/CppSamples/Features/ListRelatedFeatures/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/ServiceFeatureTableCache/Info.plist
+++ b/CppSamples/Features/ServiceFeatureTableCache/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/ServiceFeatureTableManualCache/Info.plist
+++ b/CppSamples/Features/ServiceFeatureTableManualCache/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Features/ServiceFeatureTableNoCache/Info.plist
+++ b/CppSamples/Features/ServiceFeatureTableNoCache/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/Buffer/Info.plist
+++ b/CppSamples/Geometry/Buffer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/ClipGeometry/Info.plist
+++ b/CppSamples/Geometry/ClipGeometry/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/ConvexHull/Info.plist
+++ b/CppSamples/Geometry/ConvexHull/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleIcons~ipad</key>
     <dict/>
     <key>CFBundleIdentifier</key>
-    <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+    <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/CreateAndEditGeometries/Info.plist
+++ b/CppSamples/Geometry/CreateAndEditGeometries/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/CreateGeometries/Info.plist
+++ b/CppSamples/Geometry/CreateGeometries/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/CutGeometry/Info.plist
+++ b/CppSamples/Geometry/CutGeometry/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/DensifyAndGeneralize/Info.plist
+++ b/CppSamples/Geometry/DensifyAndGeneralize/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/FormatCoordinates/Info.plist
+++ b/CppSamples/Geometry/FormatCoordinates/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/GeodesicOperations/Info.plist
+++ b/CppSamples/Geometry/GeodesicOperations/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/ListTransformations/Info.plist
+++ b/CppSamples/Geometry/ListTransformations/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/NearestVertex/Info.plist
+++ b/CppSamples/Geometry/NearestVertex/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleIcons~ipad</key>
     <dict/>
     <key>CFBundleIdentifier</key>
-    <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+    <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/ProjectGeometry/Info.plist
+++ b/CppSamples/Geometry/ProjectGeometry/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/SpatialOperations/Info.plist
+++ b/CppSamples/Geometry/SpatialOperations/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Geometry/SpatialRelationships/Info.plist
+++ b/CppSamples/Geometry/SpatialRelationships/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/AddCustomDynamicEntityDataSource/Info.plist
+++ b/CppSamples/Layers/AddCustomDynamicEntityDataSource/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/AddDynamicEntityLayer/Info.plist
+++ b/CppSamples/Layers/AddDynamicEntityLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/AddEncExchangeSet/Info.plist
+++ b/CppSamples/Layers/AddEncExchangeSet/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ApplyMosaicRuleToRasters/Info.plist
+++ b/CppSamples/Layers/ApplyMosaicRuleToRasters/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/Info.plist
+++ b/CppSamples/Layers/ApplyUniqueValuesWithAlternateSymbols/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ArcGISMapImageLayerUrl/Info.plist
+++ b/CppSamples/Layers/ArcGISMapImageLayerUrl/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ArcGISTiledLayerUrl/Info.plist
+++ b/CppSamples/Layers/ArcGISTiledLayerUrl/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/BlendRasterLayer/Info.plist
+++ b/CppSamples/Layers/BlendRasterLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/BrowseOGCAPIFeatureService/Info.plist
+++ b/CppSamples/Layers/BrowseOGCAPIFeatureService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/BrowseWfsLayers/Info.plist
+++ b/CppSamples/Layers/BrowseWfsLayers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ChangeSublayerRenderer/Info.plist
+++ b/CppSamples/Layers/ChangeSublayerRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ChangeSublayerVisibility/Info.plist
+++ b/CppSamples/Layers/ChangeSublayerVisibility/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ConfigureClusters/Info.plist
+++ b/CppSamples/Layers/ConfigureClusters/Info.plist
@@ -11,7 +11,7 @@
         <key>CFBundleIcons~ipad</key>
         <dict/>
         <key>CFBundleIdentifier</key>
-        <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+        <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
         <key>CFBundleName</key>
         <string>${PRODUCT_NAME}</string>
         <key>CFBundlePackageType</key>

--- a/CppSamples/Layers/CreateAndSaveKmlFile/Info.plist
+++ b/CppSamples/Layers/CreateAndSaveKmlFile/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplayAnnotation/Info.plist
+++ b/CppSamples/Layers/DisplayAnnotation/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplayDimensions/Info.plist
+++ b/CppSamples/Layers/DisplayDimensions/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplayFeatureLayers/Info.plist
+++ b/CppSamples/Layers/DisplayFeatureLayers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplayKml/Info.plist
+++ b/CppSamples/Layers/DisplayKml/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplayKmlNetworkLinks/Info.plist
+++ b/CppSamples/Layers/DisplayKmlNetworkLinks/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplaySubtypeFeatureLayer/Info.plist
+++ b/CppSamples/Layers/DisplaySubtypeFeatureLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/DisplayWfsLayer/Info.plist
+++ b/CppSamples/Layers/DisplayWfsLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ExportTiles/Info.plist
+++ b/CppSamples/Layers/ExportTiles/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ExportVectorTiles/Info.plist
+++ b/CppSamples/Layers/ExportVectorTiles/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/FeatureCollectionLayerFromPortal/Info.plist
+++ b/CppSamples/Layers/FeatureCollectionLayerFromPortal/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/FeatureCollectionLayerQuery/Info.plist
+++ b/CppSamples/Layers/FeatureCollectionLayerQuery/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/FeatureLayerRenderingModeMap/Info.plist
+++ b/CppSamples/Layers/FeatureLayerRenderingModeMap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/FeatureLayerRenderingModeScene/Info.plist
+++ b/CppSamples/Layers/FeatureLayerRenderingModeScene/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/Feature_Collection_Layer/Info.plist
+++ b/CppSamples/Layers/Feature_Collection_Layer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/GroupLayers/Info.plist
+++ b/CppSamples/Layers/GroupLayers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/Hillshade_Renderer/Info.plist
+++ b/CppSamples/Layers/Hillshade_Renderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/IdentifyKmlFeatures/Info.plist
+++ b/CppSamples/Layers/IdentifyKmlFeatures/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/IdentifyRasterCell/Info.plist
+++ b/CppSamples/Layers/IdentifyRasterCell/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ListKmlContents/Info.plist
+++ b/CppSamples/Layers/ListKmlContents/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/LoadWfsXmlQuery/Info.plist
+++ b/CppSamples/Layers/LoadWfsXmlQuery/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/ManageOperationalLayers/Info.plist
+++ b/CppSamples/Layers/ManageOperationalLayers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/OSM_Layer/Info.plist
+++ b/CppSamples/Layers/OSM_Layer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/PlayAKmlTour/Info.plist
+++ b/CppSamples/Layers/PlayAKmlTour/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/QueryMapImageSublayer/Info.plist
+++ b/CppSamples/Layers/QueryMapImageSublayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/QueryOGCAPICQLFilters/Info.plist
+++ b/CppSamples/Layers/QueryOGCAPICQLFilters/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterColormapRenderer/Info.plist
+++ b/CppSamples/Layers/RasterColormapRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterFunctionFile/Info.plist
+++ b/CppSamples/Layers/RasterFunctionFile/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterFunctionService/Info.plist
+++ b/CppSamples/Layers/RasterFunctionService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterLayerFile/Info.plist
+++ b/CppSamples/Layers/RasterLayerFile/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterLayerGeoPackage/Info.plist
+++ b/CppSamples/Layers/RasterLayerGeoPackage/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterLayerService/Info.plist
+++ b/CppSamples/Layers/RasterLayerService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterRenderingRule/Info.plist
+++ b/CppSamples/Layers/RasterRenderingRule/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterRgbRenderer/Info.plist
+++ b/CppSamples/Layers/RasterRgbRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/RasterStretchRenderer/Info.plist
+++ b/CppSamples/Layers/RasterStretchRenderer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/StyleWmsLayer/Info.plist
+++ b/CppSamples/Layers/StyleWmsLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/TileCacheLayer/Info.plist
+++ b/CppSamples/Layers/TileCacheLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/VectorTiledLayerUrl/Info.plist
+++ b/CppSamples/Layers/VectorTiledLayerUrl/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/WMTS_Layer/Info.plist
+++ b/CppSamples/Layers/WMTS_Layer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/Web_Tiled_Layer/Info.plist
+++ b/CppSamples/Layers/Web_Tiled_Layer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Layers/WmsLayerUrl/Info.plist
+++ b/CppSamples/Layers/WmsLayerUrl/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ApplyScheduledMapUpdates/Info.plist
+++ b/CppSamples/Maps/ApplyScheduledMapUpdates/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/BrowseBuildingFloors/Info.plist
+++ b/CppSamples/Maps/BrowseBuildingFloors/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ChangeBasemap/Info.plist
+++ b/CppSamples/Maps/ChangeBasemap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ChangeViewpoint/Info.plist
+++ b/CppSamples/Maps/ChangeViewpoint/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ConfigureBasemapStyleLanguage/Info.plist
+++ b/CppSamples/Maps/ConfigureBasemapStyleLanguage/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/CreateAndSaveMap/Info.plist
+++ b/CppSamples/Maps/CreateAndSaveMap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/CreateDynamicBasemapGallery/Info.plist
+++ b/CppSamples/Maps/CreateDynamicBasemapGallery/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/DisplayDeviceLocation/ios/Info.plist
+++ b/CppSamples/Maps/DisplayDeviceLocation/ios/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/DisplayDrawingStatus/Info.plist
+++ b/CppSamples/Maps/DisplayDrawingStatus/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/DisplayLayerViewDrawState/Info.plist
+++ b/CppSamples/Maps/DisplayLayerViewDrawState/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/DisplayMap/Info.plist
+++ b/CppSamples/Maps/DisplayMap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/DisplayOverviewMap/Info.plist
+++ b/CppSamples/Maps/DisplayOverviewMap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/DownloadPreplannedMap/Info.plist
+++ b/CppSamples/Maps/DownloadPreplannedMap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/GenerateOfflineMap/Info.plist
+++ b/CppSamples/Maps/GenerateOfflineMap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/GenerateOfflineMapLocalBasemap/Info.plist
+++ b/CppSamples/Maps/GenerateOfflineMapLocalBasemap/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/GenerateOfflineMap_Overrides/Info.plist
+++ b/CppSamples/Maps/GenerateOfflineMap_Overrides/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/HonorMobileMapPackageExpiration/Info.plist
+++ b/CppSamples/Maps/HonorMobileMapPackageExpiration/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/IdentifyLayers/Info.plist
+++ b/CppSamples/Maps/IdentifyLayers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ManageBookmarks/Info.plist
+++ b/CppSamples/Maps/ManageBookmarks/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/MapLoaded/Info.plist
+++ b/CppSamples/Maps/MapLoaded/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/MapReferenceScale/Info.plist
+++ b/CppSamples/Maps/MapReferenceScale/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/MapRotation/Info.plist
+++ b/CppSamples/Maps/MapRotation/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/MinMaxScale/Info.plist
+++ b/CppSamples/Maps/MinMaxScale/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/MobileMap_SearchAndRoute/Info.plist
+++ b/CppSamples/Maps/MobileMap_SearchAndRoute/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/OpenMapUrl/Info.plist
+++ b/CppSamples/Maps/OpenMapUrl/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/OpenMobileMap_MapPackage/Info.plist
+++ b/CppSamples/Maps/OpenMobileMap_MapPackage/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ReadGeoPackage/Info.plist
+++ b/CppSamples/Maps/ReadGeoPackage/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/SetInitialMapArea/Info.plist
+++ b/CppSamples/Maps/SetInitialMapArea/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/SetInitialMapLocation/Info.plist
+++ b/CppSamples/Maps/SetInitialMapLocation/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/SetMapSpatialReference/Info.plist
+++ b/CppSamples/Maps/SetMapSpatialReference/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/SetMaxExtent/Info.plist
+++ b/CppSamples/Maps/SetMaxExtent/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/Info.plist
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ios/Info.plist
+++ b/CppSamples/Maps/ShowDeviceLocationUsingIndoorPositioning/ios/Info.plist
@@ -11,7 +11,7 @@
         <key>CFBundleIcons~ipad</key>
         <dict/>
         <key>CFBundleIdentifier</key>
-        <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+        <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
         <key>CFBundleName</key>
         <string>${PRODUCT_NAME}</string>
         <key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ShowLocationHistory/Info.plist
+++ b/CppSamples/Maps/ShowLocationHistory/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/ShowMagnifier/Info.plist
+++ b/CppSamples/Maps/ShowMagnifier/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Maps/TakeScreenshot/Info.plist
+++ b/CppSamples/Maps/TakeScreenshot/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/ClosestFacility/Info.plist
+++ b/CppSamples/Routing/ClosestFacility/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/DisplayRouteLayer/Info.plist
+++ b/CppSamples/Routing/DisplayRouteLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/Info.plist
+++ b/CppSamples/Routing/FindClosestFacilityToMultipleIncidentsService/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/FindRoute/Info.plist
+++ b/CppSamples/Routing/FindRoute/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/FindServiceAreasForMultipleFacilities/Info.plist
+++ b/CppSamples/Routing/FindServiceAreasForMultipleFacilities/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/NavigateARouteWithRerouting/Info.plist
+++ b/CppSamples/Routing/NavigateARouteWithRerouting/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/NavigateRoute/Info.plist
+++ b/CppSamples/Routing/NavigateRoute/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/OfflineRouting/Info.plist
+++ b/CppSamples/Routing/OfflineRouting/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/RouteAroundBarriers/Info.plist
+++ b/CppSamples/Routing/RouteAroundBarriers/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Routing/ServiceArea/Info.plist
+++ b/CppSamples/Routing/ServiceArea/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/Add3DTilesLayer/Info.plist
+++ b/CppSamples/Scenes/Add3DTilesLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/AddAPointSceneLayer/Info.plist
+++ b/CppSamples/Scenes/AddAPointSceneLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/AddIntegratedMeshLayer/Info.plist
+++ b/CppSamples/Scenes/AddIntegratedMeshLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/Animate3DSymbols/Info.plist
+++ b/CppSamples/Scenes/Animate3DSymbols/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/AnimateImagesWithImageOverlay/Info.plist
+++ b/CppSamples/Scenes/AnimateImagesWithImageOverlay/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/BasicSceneView/Info.plist
+++ b/CppSamples/Scenes/BasicSceneView/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/ChangeAtmosphereEffect/Info.plist
+++ b/CppSamples/Scenes/ChangeAtmosphereEffect/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/ChooseCameraController/Info.plist
+++ b/CppSamples/Scenes/ChooseCameraController/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/Info.plist
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalRaster/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/Info.plist
+++ b/CppSamples/Scenes/CreateTerrainSurfaceFromLocalTilePackage/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/DisplaySceneLayer/Info.plist
+++ b/CppSamples/Scenes/DisplaySceneLayer/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/DistanceCompositeSymbol/Info.plist
+++ b/CppSamples/Scenes/DistanceCompositeSymbol/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/ExtrudeGraphics/Info.plist
+++ b/CppSamples/Scenes/ExtrudeGraphics/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/FeatureLayerExtrusion/Info.plist
+++ b/CppSamples/Scenes/FeatureLayerExtrusion/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/FilterFeaturesInScene/Info.plist
+++ b/CppSamples/Scenes/FilterFeaturesInScene/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/GetElevationAtPoint/Info.plist
+++ b/CppSamples/Scenes/GetElevationAtPoint/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/OpenMobileScenePackage/Info.plist
+++ b/CppSamples/Scenes/OpenMobileScenePackage/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/OpenScene/Info.plist
+++ b/CppSamples/Scenes/OpenScene/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/OrbitCameraAroundObject/Info.plist
+++ b/CppSamples/Scenes/OrbitCameraAroundObject/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/RealisticLightingAndShadows/Info.plist
+++ b/CppSamples/Scenes/RealisticLightingAndShadows/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/SceneLayerSelection/Info.plist
+++ b/CppSamples/Scenes/SceneLayerSelection/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/ScenePropertiesExpressions/Info.plist
+++ b/CppSamples/Scenes/ScenePropertiesExpressions/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/SetSurfacePlacementMode/Info.plist
+++ b/CppSamples/Scenes/SetSurfacePlacementMode/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/Symbols/Info.plist
+++ b/CppSamples/Scenes/Symbols/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/SyncMapViewSceneView/Info.plist
+++ b/CppSamples/Scenes/SyncMapViewSceneView/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/TerrainExaggeration/Info.plist
+++ b/CppSamples/Scenes/TerrainExaggeration/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/ViewContentBeneathTerrainSurface/Info.plist
+++ b/CppSamples/Scenes/ViewContentBeneathTerrainSurface/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Scenes/ViewPointCloudDataOffline/Info.plist
+++ b/CppSamples/Scenes/ViewPointCloudDataOffline/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Search/FindAddress/Info.plist
+++ b/CppSamples/Search/FindAddress/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Search/FindPlace/Info.plist
+++ b/CppSamples/Search/FindPlace/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Search/FindPlace/ios/Info.plist
+++ b/CppSamples/Search/FindPlace/ios/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Search/OfflineGeocode/Info.plist
+++ b/CppSamples/Search/OfflineGeocode/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/Search/ReverseGeocodeOnline/Info.plist
+++ b/CppSamples/Search/ReverseGeocodeOnline/Info.plist
@@ -11,7 +11,7 @@
     <key>CFBundleIcons~ipad</key>
     <dict/>
     <key>CFBundleIdentifier</key>
-    <string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+    <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
     <key>CFBundleName</key>
     <string>${PRODUCT_NAME}</string>
     <key>CFBundlePackageType</key>

--- a/CppSamples/Search/SearchDictionarySymbolStyle/Info.plist
+++ b/CppSamples/Search/SearchDictionarySymbolStyle/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/Info.plist
+++ b/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/UtilityNetwork/DisplayUtilityAssociations/Info.plist
+++ b/CppSamples/UtilityNetwork/DisplayUtilityAssociations/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/Info.plist
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/Info.plist
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/Info.plist
+++ b/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>

--- a/Templates/CppSampleTemplate/Info.plist.tmpl
+++ b/Templates/CppSampleTemplate/Info.plist.tmpl
@@ -11,7 +11,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>com.esri.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>


### PR DESCRIPTION
# Description

Xcode 16 will not launch apps with this Info.plist entry anymore. The replacement is the same one that Qt autogenerates at build time in their vanilla templates. In local testing, it works for me. I tested ContigentValue sample with Xcode 16.2.

## Type of change

- [X] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [X] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
