### PR TITLE
Use implicit width of the grid below to set the width.

### DIFF
--- a/CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
+++ b/CppSamples/Routing/RouteAroundBarriers/RouteAroundBarriers.qml
@@ -47,7 +47,7 @@ Item {
                 Layout.alignment: Qt.AlignLeft
                 Layout.margins: 3
                 Layout.bottomMargin: 0
-                width: Qt.platform.os === "ios" || Qt.platform.os === "android" ? 200 : 300
+                implicitWidth: grid.implicitWidth
                 height: childrenRect.height
                 color: "lightgrey"
 


### PR DESCRIPTION
# Description

This component doesn't size properly on mobile. The existing logic is 200 for desktops, 300 for mobile but that's not right. The new logic set the implicitWidth based on the implicitWidth of the child grid.

I tested on iOS and macOS and it looks correct.

https://doc.qt.io/qt-6/qml-qtquick-item.html#implicitWidth-prop

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [x] iOS
