### PR TITLE
Doc fixup snap rules sample

### DIFF
--- a/CppSamples/EditData/SnapGeometryEditsWithRules/README.md
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/README.md
@@ -50,6 +50,14 @@ To save your edits, press the save button.
 * SnapSourceSettings
 * UtilityNetwork
 
+## Offline data
+
+Read more about how to set up the sample's offline data [here](http://links.esri.com/ArcGISRuntimeQtSamples#use-offline-data-in-the-samples).
+
+Link | Local Location
+---------|-------|
+|[Naperville gas network](https://www.arcgis.com/home/item.html?id=0fd3a39660d54c12b05d5f81f207dffd)| `<userhome>`/ArcGIS/Runtime/Data/raster/NapervilleGasUtilities.geodatabase |
+
 ## About the data
 
 The [Naperville gas network](https://www.arcgis.com/home/item.html?id=0fd3a39660d54c12b05d5f81f207dffd) mobile geodatabase contains a utility network with a set of connectivity rules that can be used to perform geometry edits with rules based snapping.

--- a/CppSamples/EditData/SnapGeometryEditsWithRules/SnapSourcesListModel.cpp
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/SnapSourcesListModel.cpp
@@ -1,5 +1,5 @@
 // [Legal]
-// Copyright 2024 Esri.
+// Copyright 2025 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CppSamples/EditData/SnapGeometryEditsWithRules/SnapSourcesListModel.h
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/SnapSourcesListModel.h
@@ -1,5 +1,5 @@
 // [Legal]
-// Copyright 2024 Esri.
+// Copyright 2025 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/CppSamples/EditData/SnapGeometryEditsWithRules/main.cpp
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/main.cpp
@@ -1,5 +1,5 @@
 // [Legal]
-// Copyright 2024 Esri.
+// Copyright 2025 Esri.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Some of the copyright numbers were incorrect in my latest snapping sample. Also, I had forgotten we have an `Offline data` snippet we include when samples require offline data.

