### PR TITLE
KmlMultiTrack sample - Fixed the steps in README

### DIFF
--- a/CppSamples/EditData/CreateKmlMultiTrack/README.md
+++ b/CppSamples/EditData/CreateKmlMultiTrack/README.md
@@ -10,7 +10,7 @@ When capturing location data for outdoor activities such as hiking or skiing, it
 
 ## How to use the sample
 
-Tap **Start Navigation** to begin moving along a simulated trail. Tap **Record Track** to start recording your current path. Tap **Stop Recording** to end recording and capture a KML track. Repeat these steps to capture multiple KML tracks in a single session. Tap the **Save** button to save your recorded tracks as a `.kmz` file to local storage. Then load the created `.kmz` file containing your KML multi-track to view all created tracks on the map.
+Start the KML multi track sample application to begin moving along a simulated trail. Tap **Record Track(s)** to start recording your current path. Tap **Stop Recording** to end recording and capture a KML track. Repeat these steps to capture multiple KML tracks in a single session. Tap the **Save** button to save your recorded tracks as a `.kmz` file to local storage. Then load the created `.kmz` file containing your KML multi-track to view all created tracks on the map. Tap the **Recenter** icon to position the location at the center of the map view.  
 
 ## How it works
 


### PR DESCRIPTION
# Description

Modified the` ## How to use the sample` to fix the Kathleen's feedback - 'Description > How to use the sample, states to Start Navigation. there is no Start Navigation.'

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [x] Windows
- [ ] Android
- [ ] Linux
- [ ] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
