### PR TITLE
Add metadata for required data on sample

### DIFF
--- a/CppSamples/EditData/SnapGeometryEditsWithRules/README.metadata.json
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/README.metadata.json
@@ -1,5 +1,11 @@
 {
     "category": "Utility network",
+    "dataItems": [
+        {
+            "itemId": "0fd3a39660d54c12b05d5f81f207dffd",
+            "path": "~/ArcGIS/Runtime/Data/geodatabase/NapervilleGasUtilities.geodatabase"
+        }
+    ],
     "description": "Use the Geometry Editor to edit geometries using utility network connectivity rules.",
     "featured": false,
     "ignore": false,


### PR DESCRIPTION
# Description

Add dataItems entry in the metadata of new snapping sample to enable the download manager kicking in if user is missing data.