### PR TITLE
Run all continuations on the app's thread.

### DIFF
--- a/CppSamples/Analysis/Geotriggers/Geotriggers.cpp
+++ b/CppSamples/Analysis/Geotriggers/Geotriggers.cpp
@@ -233,7 +233,7 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
   emit displayInfoChanged();
   // enableAutoFetch and enableAutoApplyEdits for AttachmentListModel are set as false
   // to avoid automatic behavior. We will call fetchDataAsync explicitly as needed.
-  feature->attachments(false, false)->fetchAttachmentsAsync().then(
+  feature->attachments(false, false)->fetchAttachmentsAsync().then(this,
       [this, sectionName](const QList<Attachment*>& attachments)
       {
         if (attachments.isEmpty())
@@ -247,7 +247,7 @@ void Geotriggers::getFeatureInformation(const QString& sectionName)
           m_featureAttachmentImageUrls[sectionName] = sectionImageAttachment->attachmentUrl();
           m_currentFeatureImageUrl = m_featureAttachmentImageUrls[sectionName];
           emit displayInfoChanged();
-        }); 
+        });
       });
   m_gardenSections->applyEditsAsync(this).then(this, [](QList<FeatureEditResult*> results)
   {

--- a/CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
+++ b/CppSamples/CloudAndPortal/AddItemsToPortal/AddItemsToPortal.cpp
@@ -170,7 +170,7 @@ void AddItemsToPortal::addItem()
 
   //! [PortalUser addItemWithUrlAsync]
   QUrl localCSV("qrc:/Samples/CloudAndPortal/AddItemsToPortal/add_item_sample.csv");
-  m_user->addPortalItemWithUrlAsync(m_item, localCSV, "add_item_sample.csv" ).then(
+  m_user->addPortalItemWithUrlAsync(m_item, localCSV, "add_item_sample.csv" ).then(this,
   [this]()
   {
     m_busy = false;
@@ -207,7 +207,7 @@ void AddItemsToPortal::deleteItem()
 
   m_busy = true;
 
-  m_user->deletePortalItemAsync(m_item).then(
+  m_user->deletePortalItemAsync(m_item).then(this,
   [this]()
   {
     m_busy = false;
@@ -235,7 +235,7 @@ void AddItemsToPortal::fetchItem()
 
   m_busy = true;
 
-  m_user->fetchContentAsync().then(
+  m_user->fetchContentAsync().then(this,
   [this]()
   {
     m_busy = false;

--- a/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.cpp
+++ b/CppSamples/CloudAndPortal/IntegratedWindowsAuthentication/IntegratedWindowsAuthentication.cpp
@@ -128,7 +128,7 @@ void IntegratedWindowsAuthentication::securePortalDoneLoading(const Error& loadE
     return;
   }
 
-  m_iwaSecurePortal->findItemsAsync(*query).then(
+  m_iwaSecurePortal->findItemsAsync(*query).then(this,
   [this](PortalQueryResultSetForItems* result)
   {
     searchItemsCompleted(result);

--- a/CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.cpp
+++ b/CppSamples/CloudAndPortal/SearchForWebmap/SearchForWebmap.cpp
@@ -112,7 +112,7 @@ void SearchForWebmap::search(const QString& keyword)
                         .arg(keyword, fromDate, toDate));
   query.setTypes(QList<PortalItemType>() << PortalItemType::WebMap);
 
-  m_portal->findItemsAsync(query).then(
+  m_portal->findItemsAsync(query).then(this,
   [this](PortalQueryResultSetForItems* webmapResults)
   {
     onFindItemsCompleted(webmapResults);
@@ -133,7 +133,7 @@ void SearchForWebmap::searchNext()
   // check whether the startIndex of the new query is valid
   if (!nextQuery.isEmpty())
   {
-    m_portal->findItemsAsync(nextQuery).then(
+    m_portal->findItemsAsync(nextQuery).then(this,
     [this](PortalQueryResultSetForItems* webmapResults)
     {
       onFindItemsCompleted(webmapResults);

--- a/CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
+++ b/CppSamples/CloudAndPortal/ShowOrgBasemaps/ShowOrgBasemaps.cpp
@@ -71,7 +71,7 @@ void ShowOrgBasemaps::connectLoadStatusSignal()
 
       if (m_portalLoaded)
       {
-        m_portal->fetchBasemapsAsync().then(
+        m_portal->fetchBasemapsAsync().then(this,
         [this]()
         {
           emit basemapsChanged();

--- a/CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
+++ b/CppSamples/EditData/EditFeatureAttachments/EditFeatureAttachments.cpp
@@ -249,7 +249,7 @@ void EditFeatureAttachments::onQueryFeaturesCompleted_(FeatureQueryResult* featu
     // get the number of attachments
     // enableAutoFetch and enableAutoApplyEdits for AttachmentListModel are set as false
     // to avoid automatic behavior. We will call fetchDataAsync explicitly as needed.
-    m_selectedFeature->attachments(false, false)->fetchAttachmentsAsync().then([this](const QList<Attachment*>& attachments)
+    m_selectedFeature->attachments(false, false)->fetchAttachmentsAsync().then(this, [this](const QList<Attachment*>& attachments)
     {
       m_mapView->calloutData()->setDetail(QString("Number of attachments: %1").arg(attachments.size()));
       m_mapView->calloutData()->setVisible(true); // Resizes the calloutData after details has been set.

--- a/CppSamples/EditData/SnapGeometryEditsWithRules/SnapGeometryEditsWithRules.cpp
+++ b/CppSamples/EditData/SnapGeometryEditsWithRules/SnapGeometryEditsWithRules.cpp
@@ -147,10 +147,10 @@ void SnapGeometryEditsWithRules::initializeMap()
   m_map->setInitialViewpoint(Viewpoint(Point(-9811055.156028448, 5131792.19502501, SpatialReference::webMercator()), 10000));
 
   // Load the geodatabase
-  loadGeodatabase().then(
+  loadGeodatabase().then(this,
   [this]()
   {
-    loadOperationalLayers().then(
+    loadOperationalLayers().then(this,
     [this](const LoadOperationalLayersReturnStruct& layers)
     {
       // Pass the returned pipeLayer and deviceLayer from the future to modify their visibility
@@ -208,7 +208,7 @@ QFuture<LoadOperationalLayersReturnStruct> SnapGeometryEditsWithRules::loadOpera
   m_map->operationalLayers()->append(junctionLayer);
   layerLoadingFutures.emplace_back(load(junctionLayer));
 
-  return QtFuture::whenAll(layerLoadingFutures.begin(), layerLoadingFutures.end()).then(
+  return QtFuture::whenAll(layerLoadingFutures.begin(), layerLoadingFutures.end()).then(this,
   [pipeLayer, deviceLayer](const QList<QFuture<void>>&)
   {
     return LoadOperationalLayersReturnStruct{pipeLayer, deviceLayer};
@@ -265,7 +265,7 @@ void SnapGeometryEditsWithRules::onMapViewClicked(const QMouseEvent& mouseEvent)
   }
 
   // Identify the feature at the tapped location.
-  m_mapView->identifyLayersAsync(mouseEvent.position(), 5, false).then(
+  m_mapView->identifyLayersAsync(mouseEvent.position(), 5, false).then(this,
   [this](const QList<IdentifyLayerResult*>& identifyResult)
   {
     ArcGISFeature* selectedFeature = getFeatureFromResult(identifyResult);
@@ -395,7 +395,7 @@ void SnapGeometryEditsWithRules::stopEditing()
   if (m_selectedFeature)
   {
     m_selectedFeature->setGeometry(geometry);
-    m_selectedFeature->featureTable()->updateFeatureAsync(m_selectedFeature).then(
+    m_selectedFeature->featureTable()->updateFeatureAsync(m_selectedFeature).then(this,
     [this]()
     {
       // Reset the selection.
@@ -472,7 +472,7 @@ void SnapGeometryEditsWithRules::setSnapSettings(UtilityAssetType* assetType)
   }
 
   // Get the snap rules associated with the asset type.
-  SnapRules::createAsync(m_mapView->map()->utilityNetworks()->first(), assetType).then(
+  SnapRules::createAsync(m_mapView->map()->utilityNetworks()->first(), assetType).then(this,
   [this](SnapRules* createdRules)
   {
     // Synchronize the snap source collection with the map's operational layers using the snap rules.

--- a/CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
+++ b/CppSamples/Maps/CreateAndSaveMap/CreateAndSaveMap.cpp
@@ -129,7 +129,7 @@ void CreateAndSaveMap::saveMap(const QString& title, const QString& tags, const 
   const QByteArray thumbnail;
 
   // save the map
-  m_map->saveAsAsync(m_portal, title, tagsList, forceSave, folder, description, thumbnail).then(
+  m_map->saveAsAsync(m_portal, title, tagsList, forceSave, folder, description, thumbnail).then(this,
   [this]()
   {
     const QString itemId = m_map->item()->itemId();

--- a/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.cpp
+++ b/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.cpp
@@ -397,7 +397,7 @@ void ValidateUtilityNetworkTopology::onGetState()
 
     updateMessage("Getting utility network state...");
 
-    m_utilityNetwork->stateAsync().then([this](const QFuture<Esri::ArcGISRuntime::UtilityNetworkState*>& state)
+    m_utilityNetwork->stateAsync().then(this, [this](const QFuture<Esri::ArcGISRuntime::UtilityNetworkState*>& state)
     {
       m_utilityNetworkstate = state.result();
 

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -559,7 +559,7 @@ void SampleManager::fetchPortalItemData(const QString& itemId, const QString& ou
       {
         auto folder = portalItem->type() == PortalItemType::CodeSample ? portalItem->name() : QString();
         QString formattedPath = SampleManager::formattedPath(outputPath, folder);
-        portalItem->fetchDataAsync(formattedPath).then([this, portalItem, formattedPath]()
+        portalItem->fetchDataAsync(formattedPath).then(this, [this, portalItem, formattedPath]()
         {
           setDownloadProgress(0.0);
           if (QFileInfo(formattedPath).suffix() == "zip")


### PR DESCRIPTION
This can cause problems if we don't when there's a need to set parents across thread on new objects.

This is primarily defensive changes. Not all of these are associated with any specific problems, but we want to encourage best practices and consistency, so it is best to run continuations on the app's thread and not directly on callbacks initiated from internal code on a QThread. In some situations setting parents can be problematic.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS
