### PR TITLE
continueAndFailWithError is deprecated, replaced with continueWithError

### DIFF
--- a/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
+++ b/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.cpp
@@ -424,6 +424,6 @@ void EditWithBranchVersioning::handleArcGISAuthenticationChallenge(ArcGISAuthent
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cpp
+++ b/CppSamples/Layers/DisplaySubtypeFeatureLayer/DisplaySubtypeFeatureLayer.cpp
@@ -193,6 +193,6 @@ void DisplaySubtypeFeatureLayer::handleArcGISAuthenticationChallenge(ArcGISAuthe
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.cpp
+++ b/CppSamples/UtilityNetwork/ConfigureSubnetworkTrace/ConfigureSubnetworkTrace.cpp
@@ -378,6 +378,6 @@ void ConfigureSubnetworkTrace::handleArcGISAuthenticationChallenge(ArcGISAuthent
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.cpp
+++ b/CppSamples/UtilityNetwork/CreateLoadReport/CreateLoadReport.cpp
@@ -318,6 +318,6 @@ void CreateLoadReport::handleArcGISAuthenticationChallenge(ArcGISAuthenticationC
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
+++ b/CppSamples/UtilityNetwork/DisplayContentOfUtilityNetworkContainer/DisplayContentOfUtilityNetworkContainer.cpp
@@ -409,6 +409,6 @@ void DisplayContentOfUtilityNetworkContainer::handleArcGISAuthenticationChalleng
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
+++ b/CppSamples/UtilityNetwork/DisplayUtilityAssociations/DisplayUtilityAssociations.cpp
@@ -91,7 +91,7 @@ void DisplayUtilityAssociations::handleArcGISAuthenticationChallenge(ArcGISAuthe
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }
 

--- a/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
+++ b/CppSamples/UtilityNetwork/PerformValveIsolationTrace/PerformValveIsolationTrace.cpp
@@ -489,6 +489,6 @@ void PerformValveIsolationTrace::handleArcGISAuthenticationChallenge(ArcGISAuthe
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
+++ b/CppSamples/UtilityNetwork/TraceUtilityNetwork/TraceUtilityNetwork.cpp
@@ -487,6 +487,6 @@ void TraceUtilityNetwork::handleArcGISAuthenticationChallenge(ArcGISAuthenticati
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }

--- a/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.cpp
+++ b/CppSamples/UtilityNetwork/ValidateUtilityNetworkTopology/ValidateUtilityNetworkTopology.cpp
@@ -704,6 +704,6 @@ void ValidateUtilityNetworkTopology::handleArcGISAuthenticationChallenge(ArcGISA
     challenge->continueWithCredential(tokenCredential);
   }).onFailed(this, [challenge](const ErrorException& e)
   {
-    challenge->continueAndFailWithError(e.error());
+    challenge->continueWithError(e.error());
   });
 }


### PR DESCRIPTION
# Description
Replaced the deprecated `continueAndFailWithError` with `continueWithError`

<!--- Summary of the change and any relevant info. -->

## Type of change

- [ ] Bug fix
- [ ] New sample implementation
- [x] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
