### PR TITLE
SampleViewer Fix: cache original challenge handler and reset it before every sample load.

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -347,7 +347,8 @@ void SampleManager::setCurrentMode(const CurrentMode& mode)
   emit currentModeChanged();
 }
 
-void SampleManager::cacheToolkitChallengeHandler() {
+void SampleManager::cacheToolkitChallengeHandler() 
+{
   if ( m_previousChallengeHandler == nullptr )
   {
     // cache the original toolkit challenge handler

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -349,10 +349,10 @@ void SampleManager::setCurrentMode(const CurrentMode& mode)
 
 void SampleManager::cacheToolkitChallengeHandler() 
 {
-  if ( m_previousChallengeHandler == nullptr )
+  if (m_toolkitChallengeHandler == nullptr)
   {
     // cache the original toolkit challenge handler
-    m_previousChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
+    m_toolkitChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
   }
 }
 
@@ -444,10 +444,10 @@ void SampleManager::resetAuthenticationState()
   // and remove any oauth configurations
   Toolkit::OAuthUserConfigurationManager::clearConfigurations();
 
-  if (m_previousChallengeHandler != nullptr)
+  if (m_toolkitChallengeHandler != nullptr)
   {
     // when sample changes, restore the original toolkit challenge handler
-    ArcGISRuntimeEnvironment::authenticationManager()->setArcGISAuthenticationChallengeHandler(m_previousChallengeHandler);
+    ArcGISRuntimeEnvironment::authenticationManager()->setArcGISAuthenticationChallengeHandler(m_toolkitChallengeHandler);
   }
 }
 

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -443,8 +443,6 @@ void SampleManager::resetAuthenticationState()
   // and remove any oauth configurations
   Toolkit::OAuthUserConfigurationManager::clearConfigurations();
 
-  // the AuthenticatorController is a singleton, so do not remove its challenge handlers
-  // since they still need to be available to handle challenges for various samples
   if ( m_previousChallengeHandler != nullptr )
   {
     // when sample changes, restore the original toolkit challenge handler

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -349,11 +349,7 @@ void SampleManager::setCurrentMode(const CurrentMode& mode)
 
 void SampleManager::cacheToolkitChallengeHandler() 
 {
-  if (m_toolkitChallengeHandler == nullptr)
-  {
-    // cache the original toolkit challenge handler
-    m_toolkitChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
-  }
+  m_toolkitChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
 }
 
 void SampleManager::setCurrentSample(Sample* sample)

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -347,8 +347,17 @@ void SampleManager::setCurrentMode(const CurrentMode& mode)
   emit currentModeChanged();
 }
 
+void SampleManager::cacheToolkitChallengeHandler() {
+  if ( m_previousChallengeHandler == nullptr )
+  {
+    // cache the original toolkit challenge handler
+    m_previousChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
+  }
+}
+
 void SampleManager::setCurrentSample(Sample* sample)
 {
+  cacheToolkitChallengeHandler();
   m_currentSample = sample;
 
   // NOTE - currently we know we cannot set an API Key for the
@@ -371,6 +380,7 @@ void SampleManager::setCurrentSample(Sample* sample)
 
 void SampleManager::setCurrentSample(const QVariant& sample)
 {
+  cacheToolkitChallengeHandler();
   if (sample.isValid())
   {
     auto samplePtr = qvariant_cast<Sample*>(sample);
@@ -435,6 +445,11 @@ void SampleManager::resetAuthenticationState()
 
   // the AuthenticatorController is a singleton, so do not remove its challenge handlers
   // since they still need to be available to handle challenges for various samples
+  if ( m_previousChallengeHandler != nullptr )
+  {
+    // when sample changes, restore the original toolkit challenge handler
+    ArcGISRuntimeEnvironment::authenticationManager()->setArcGISAuthenticationChallengeHandler(m_previousChallengeHandler);
+  }
 }
 
 bool SampleManager::dataItemsExists()

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -444,7 +444,7 @@ void SampleManager::resetAuthenticationState()
   // and remove any oauth configurations
   Toolkit::OAuthUserConfigurationManager::clearConfigurations();
 
-  if ( m_previousChallengeHandler != nullptr )
+  if (m_previousChallengeHandler != nullptr)
   {
     // when sample changes, restore the original toolkit challenge handler
     ArcGISRuntimeEnvironment::authenticationManager()->setArcGISAuthenticationChallengeHandler(m_previousChallengeHandler);

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -1,18 +1,5 @@
-// COPYRIGHT 2025 ESRI
-// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
-// Unpublished material - all rights reserved under the
-// Copyright Laws of the United States and applicable international
-// laws, treaties, and conventions.
-//
-// For additional information, contact:
-// Environmental Systems Research Institute, Inc.
-// Attn: Contracts and Legal Services Department
-// 380 New York Street
-// Redlands, California, 92373
-// USA
-//
-// email: contracts@esri.com
-/// \file SampleManager.h
+// [Legal]
+// Copyright 2022 Esri.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -1,5 +1,18 @@
-// [Legal]
-// Copyright 2022 Esri.
+// COPYRIGHT 2025 ESRI
+// TRADE SECRETS: ESRI PROPRIETARY AND CONFIDENTIAL
+// Unpublished material - all rights reserved under the
+// Copyright Laws of the United States and applicable international
+// laws, treaties, and conventions.
+//
+// For additional information, contact:
+// Environmental Systems Research Institute, Inc.
+// Attn: Contracts and Legal Services Department
+// 380 New York Street
+// Redlands, California, 92373
+// USA
+//
+// email: contracts@esri.com
+/// \file SampleManager.h
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +39,7 @@ class SampleCategory;
 class Sample;
 
 namespace Esri::ArcGISRuntime { class Portal; }
+namespace Esri::ArcGISRuntime::Authentication { class ArcGISAuthenticationChallengeHandler; }
 
 #include <QDir>
 #include <QJsonDocument>
@@ -133,6 +147,7 @@ private:
   CurrentMode currentMode() { return m_currentMode; }
   void setCurrentMode(const CurrentMode& mode);
   Sample* currentSample() const { return m_currentSample; }
+  void cacheToolkitChallengeHandler();
   void setCurrentSample(Sample* sample);
   void setCurrentSample(const QVariant& sample);
   SampleCategory* currentCategory() const { return m_currentCategory; }
@@ -178,6 +193,7 @@ private:
   std::unique_ptr<QTemporaryDir> m_tempDir;
   bool m_cancelDownload = false;
   bool m_downloadFailed = false;
+  Esri::ArcGISRuntime::Authentication::ArcGISAuthenticationChallengeHandler* m_previousChallengeHandler = nullptr;
 };
 
 #endif // SAMPLEMANAGER_H

--- a/SampleViewer/SampleManager.h
+++ b/SampleViewer/SampleManager.h
@@ -180,7 +180,7 @@ private:
   std::unique_ptr<QTemporaryDir> m_tempDir;
   bool m_cancelDownload = false;
   bool m_downloadFailed = false;
-  Esri::ArcGISRuntime::Authentication::ArcGISAuthenticationChallengeHandler* m_previousChallengeHandler = nullptr;
+  Esri::ArcGISRuntime::Authentication::ArcGISAuthenticationChallengeHandler* m_toolkitChallengeHandler = nullptr;
 };
 
 #endif // SAMPLEMANAGER_H


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [x] Runs and compiles in the sample viewer(s)
- [x] Branch is up to date with the latest main/v.next
- [x] All merge conflicts have been resolved
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] No unrelated changes have been made to any other code or project files
- [x] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
