### PR TITLE
SampleViewer: crash fix

### DIFF
--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -349,7 +349,9 @@ void SampleManager::setCurrentMode(const CurrentMode& mode)
 
 void SampleManager::cacheToolkitChallengeHandler() 
 {
-  m_toolkitChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
+  // Only cache the first instance of the challenge handler from the toolkit
+  if (m_toolkitChallengeHandler == nullptr)
+    m_toolkitChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
 }
 
 void SampleManager::setCurrentSample(Sample* sample)

--- a/SampleViewer/SampleManager.cpp
+++ b/SampleViewer/SampleManager.cpp
@@ -351,7 +351,9 @@ void SampleManager::cacheToolkitChallengeHandler()
 {
   // Only cache the first instance of the challenge handler from the toolkit
   if (m_toolkitChallengeHandler == nullptr)
+  {
     m_toolkitChallengeHandler = ArcGISRuntimeEnvironment::authenticationManager()->arcGISAuthenticationChallengeHandler();
+  }
 }
 
 void SampleManager::setCurrentSample(Sample* sample)


### PR DESCRIPTION
cache the original which comes from the toolkit. If we do subsequent calls of this where a sample inherits the handler the individual sample themselves will go out of scope and crash when we try to reassign it.

# Description

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
