### PR TITLE
Update scale in display overview map

### DIFF
--- a/CppSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.cpp
+++ b/CppSamples/Maps/DisplayOverviewMap/DisplayOverviewMap.cpp
@@ -38,7 +38,7 @@ DisplayOverviewMap::DisplayOverviewMap(QObject* parent /* = nullptr */):
   QObject(parent),
   m_map(new Map(new Basemap(BasemapStyle::ArcGISTopographic, this), this))
 {
-  m_map->setInitialViewpoint(Viewpoint(49.28299, -123.12052, 70000));
+  m_map->setInitialViewpoint(Viewpoint(49.28299, -123.12052, 66619));
 
   // Access the feature layer and add it to the maps operational layers.
   ServiceFeatureTable* serviceFeatureTable = new ServiceFeatureTable(QUrl("https://services6.arcgis.com/Do88DoK2xjTUCXd1/arcgis/rest/services/OSM_NA_Tourism/FeatureServer/0"), this);


### PR DESCRIPTION
# Description

<!--- Summary of the change and any relevant info. -->
The symbols were not visible on opening the display overview map sample after portal update. This PR is to update the scale to fix that.

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
