### PR TITLE
Change error check for login dismissed

### DIFF
--- a/CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.cpp
+++ b/CppSamples/CloudAndPortal/PortalUserInfo/PortalUserInfo.cpp
@@ -96,7 +96,7 @@ bool PortalUserInfo::loaded()
 bool PortalUserInfo::loginDismissed()
 {
   if (m_portal)
-    return m_portal->loadError().message() == "Code unauthorized." || m_portal->loadError().message() == "User canceled error.";
+    return m_portal->loadError().message().contains("canceled");
 
   return false;
 }


### PR DESCRIPTION
# Description

After transitioning to the new core auth system, the error message we receive when a user cancels the auth dialog has changed to `"The authentication challenge was canceled."`

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
