### PR TITLE
Authenticator removed

### DIFF
--- a/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
+++ b/CppSamples/EditData/EditWithBranchVersioning/EditWithBranchVersioning.qml
@@ -265,11 +265,6 @@ Item {
         accessComboBox.currentIndex = 0;
     }
 
-    // Declare Authenticator to handle any authentication challenges
-    Authenticator {
-        anchors.fill: parent
-    }
-
     // Declare the C++ instance which creates the map etc. and supply the view
     EditWithBranchVersioningSample {
         id: model


### PR DESCRIPTION
# Description

`Authenticator{}` removed from the qml as we already handle the challenges in cpp side.
Also verified other samples they do not have `Authenticator` in qml when handled the challenges already in cpp.

<!--- Summary of the change and any relevant info. -->

## Type of change

- [x] Bug fix
- [ ] New sample implementation
- [ ] Sample viewer enhancement
- [ ] Other enhancement

**Platforms tested on**:

<!--- Delete any that aren't needed -->

- [ ] Windows
- [ ] Android
- [ ] Linux
- [x] macOS
- [ ] iOS

## Checklist

- [ ] Runs and compiles on all active platforms as a standalone sample
- [ ] Runs and compiles in the sample viewer(s)
- [ ] Branch is up to date with the latest main/v.next
- [ ] All merge conflicts have been resolved
- [ ] Self-review of changes
- [ ] There are no warnings related to changes
- [ ] No unrelated changes have been made to any other code or project files
- [ ] Code is commented with correct formatting (CTRL+i)
- [ ] All variable and method names are camel case
- [ ] There is no leftover commented code
- [ ] Screenshots are correct size and display in description tab (500px by 500px, platform agnostic)
- [ ] If adding a new sample, it is added to the sample viewer
- [ ] Cherry-picked to Main branch (if applicable)
